### PR TITLE
These changes add support for reading and setting Info Chunk

### DIFF
--- a/src/sndfile.h.in
+++ b/src/sndfile.h.in
@@ -214,7 +214,12 @@ enum
 	** They currently do nothing and will continue to do nothing.
 	*/
 	SFC_SET_ADD_DITHER_ON_WRITE		= 0x1070,
-	SFC_SET_ADD_DITHER_ON_READ		= 0x1071
+	SFC_SET_ADD_DITHER_ON_READ		= 0x1071,
+	
+	/* Allow setting & reading INFO Chunk Strings */
+	
+	SFC_GET_LIST_STRING				= 0x1501,
+	SFC_SET_LIST_STRING				= 0x1502
 } ;
 
 
@@ -234,7 +239,9 @@ enum
 	SF_STR_ALBUM					= 0x07,
 	SF_STR_LICENSE					= 0x08,
 	SF_STR_TRACKNUMBER				= 0x09,
-	SF_STR_GENRE					= 0x10
+	SF_STR_GENRE					= 0x10,
+	SF_STR_INTROMS					= 0x0a,
+	SF_STR_SEGUEMS					= 0x0b
 } ;
 
 /*
@@ -243,7 +250,7 @@ enum
 */
 
 #define	SF_STR_FIRST	SF_STR_TITLE
-#define	SF_STR_LAST		SF_STR_GENRE
+#define	SF_STR_LAST		SF_STR_SEGUEMS
 
 enum
 {	/* True and false */
@@ -500,6 +507,14 @@ typedef struct SF_CART_TIMER SF_CART_TIMER ;
 			}
 
 typedef SF_CART_INFO_VAR (256) SF_CART_INFO ;
+
+#define	SF_LIST_STRING_VAR(p_string_size) \
+			struct \
+			{	int			list_enum ; \
+				char		value[p_string_size] ; \
+			}
+
+typedef SF_LIST_STRING_VAR (2048) SF_LIST_STRING ;
 
 /*	Virtual I/O functionality. */
 

--- a/src/sndfile.h.in
+++ b/src/sndfile.h.in
@@ -250,7 +250,7 @@ enum
 */
 
 #define	SF_STR_FIRST	SF_STR_TITLE
-#define	SF_STR_LAST		SF_STR_SEGUEMS
+#define	SF_STR_LAST		SF_STR_GENRE
 
 enum
 {	/* True and false */

--- a/src/strings.c
+++ b/src/strings.c
@@ -118,6 +118,8 @@ psf_store_string (SF_PRIVATE *psf, int str_type, const char *str)
 		case SF_STR_LICENSE :
 		case SF_STR_TRACKNUMBER :
 		case SF_STR_GENRE :
+		case SF_STR_INTROMS:
+		case SF_STR_SEGUEMS:
 				break ;
 
 		default :

--- a/src/wav.c
+++ b/src/wav.c
@@ -105,6 +105,8 @@
 #define ICMT_MARKER		(MAKE_MARKER ('I', 'C', 'M', 'T'))
 #define IAUT_MARKER		(MAKE_MARKER ('I', 'A', 'U', 'T'))
 #define ITRK_MARKER		(MAKE_MARKER ('I', 'T', 'R', 'K'))
+#define ISRF_MARKER		(MAKE_MARKER ('I', 'S', 'R', 'F'))
+#define IMED_MARKER		(MAKE_MARKER ('I', 'M', 'E', 'D'))
 
 /* Weird WAVPACK marker which can show up at the start of the DATA section. */
 #define wvpk_MARKER (MAKE_MARKER ('w', 'v', 'p', 'k'))
@@ -1287,6 +1289,14 @@ wav_write_strings (SF_PRIVATE *psf, int location)
 				psf_binheader_writef (psf, "ms", ITRK_MARKER, psf->strings.storage + psf->strings.data [k].offset) ;
 				break ;
 
+			case SF_STR_INTROMS :
+				psf_binheader_writef (psf, "ms", ISRF_MARKER, psf->strings.storage + psf->strings.data [k].offset) ;
+				break ;
+
+			case SF_STR_SEGUEMS :
+				psf_binheader_writef (psf, "ms", IMED_MARKER, psf->strings.storage + psf->strings.data [k].offset) ;
+				break ;
+
 			default :
 				break ;
 			} ;
@@ -1534,6 +1544,12 @@ wav_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 					break ;
 			case ITRK_MARKER :
 					psf_store_string (psf, SF_STR_TRACKNUMBER, buffer) ;
+					break ;
+			case ISRF_MARKER :
+					psf_store_string (psf, SF_STR_INTROMS, buffer) ;
+					break ;
+			case IMED_MARKER :
+					psf_store_string (psf, SF_STR_SEGUEMS, buffer) ;
 					break ;
 			} ;
 		} ;

--- a/src/wav.c
+++ b/src/wav.c
@@ -1454,6 +1454,8 @@ wav_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 			case ISRC_MARKER :
 			case IAUT_MARKER :
 			case ITRK_MARKER :
+			case ISRF_MARKER :
+			case IMED_MARKER :
 					bytesread += psf_binheader_readf (psf, "4", &chunk_size) ;
 					chunk_size += (chunk_size & 1) ;
 					if (chunk_size >= SIGNED_SIZEOF (buffer) || chunk_size >= chunk_length)


### PR DESCRIPTION
fields on Wave Files by adding two new commands -
SFC_GET_LIST_STRING
SFC_SET_LIST_STRING

Both commands accept a parameter of type SF_LIST_STRING_VAR which like SF_CART_INFO_VAR uses a macro to create a variable sized struct.

Two new String types SF_STR_INTROMS & SF_STR_SEGUEMS are defined to enable support for software which set the ISRF_MARKER & IMED_MARKER on Info chunks. Using SFC_GET_LIST_STRING + SFC_SET_LIST_STRING on a for loop effectively allows you to also copy LIST/INFO Chunk strings from one Wave file to another.