### PR TITLE
Separate out the configure flags for libflac, libogg and libvorbis

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,8 +126,19 @@ AC_ARG_ENABLE(sqlite,
 AC_ARG_ENABLE(alsa,
 	AC_HELP_STRING([--disable-alsa], [disable use of ALSA]))
 
+AC_ARG_ENABLE(libflac,
+	AC_HELP_STRING([--disable-libflac], [disable use of external FLAC library]))
+
+AC_ARG_ENABLE(libogg,
+	AC_HELP_STRING([--disable-libogg], [disable use of external Ogg library]))
+
+AC_ARG_ENABLE(libvorbis,
+	AC_HELP_STRING([--disable-libvorbis], [disable use of external Vorbis library]))
+
+# Once, you could only have all or none of FLAC, Ogg and Vorbis via this option.
+# We keep it to avoid breaking OpenWRT, OpenEmbedded and others' build scripts.
 AC_ARG_ENABLE(external-libs,
-	AC_HELP_STRING([--disable-external-libs], [disable use of FLAC, Ogg and Vorbis [[default=no]]]))
+	AC_HELP_STRING([--disable-external-libs], [disable all external libraries]))
 
 AC_ARG_ENABLE(octave,
 	AC_HELP_STRING([--enable-octave], [disable building of GNU Octave module]))
@@ -290,60 +301,67 @@ else
 #====================================================================================
 # Check for Ogg, Vorbis and FLAC.
 
-HAVE_EXTERNAL_LIBS=0
+HAVE_LIBFLAC=0
+HAVE_LIBOGG=0
+HAVE_LIBVORBIS=0
 EXTERNAL_CFLAGS=""
 EXTERNAL_LIBS=""
+
+if test x$enable_external_libs = xno ; then
+	AC_MSG_WARN([[*** External libraries disabled. ***]])
+	enable_libflac=no
+	enable_libogg=no
+	enable_libvorbis=no
+	fi
 
 # Check for pkg-config outside the if statement.
 PKG_PROG_PKG_CONFIG
 m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR], AC_SUBST([pkgconfigdir], ${libdir}/pkgconfig))
 
 if test -n "$PKG_CONFIG" ; then
-	if test x$enable_external_libs = xno ; then
-		AC_MSG_WARN([[*** External libs (FLAC, Ogg, Vorbis) disabled. ***]])
-	else
-		PKG_CHECK_MOD_VERSION(FLAC, flac >= 1.3.1, ac_cv_flac=yes, ac_cv_flac=no)
+	if test x$enable_libflac != xno ; then
+		PKG_CHECK_MOD_VERSION(FLAC, flac >= 1.3.0, ac_cv_flac=yes, ac_cv_flac=no)
 
 		# Make sure the FLAC_CFLAGS value is sane.
 		FLAC_CFLAGS=`echo $FLAC_CFLAGS | $SED "s|include/FLAC|include|"`
+		fi
 
+	if test x$enable_libogg != xno ; then
 		PKG_CHECK_MOD_VERSION(OGG, ogg >= 1.1.3, ac_cv_ogg=yes, ac_cv_ogg=no)
+		fi
 
-		if test x$enable_experimental = xyes ; then
-			PKG_CHECK_MOD_VERSION(SPEEX, speex >= 1.2, ac_cv_speex=yes, ac_cv_speex=no)
-		else
-			SPEEX_CFLAGS=""
-			SPEEX_LIBS=""
-			fi
+	if test x$enable_experimental = xyes ; then
+		PKG_CHECK_MOD_VERSION(SPEEX, speex >= 1.2, ac_cv_speex=yes, ac_cv_speex=no)
+	else
+		SPEEX_CFLAGS=""
+		SPEEX_LIBS=""
+		fi
 
+	if test x$enable_libvorbis != xno ; then
 		# Vorbis versions earlier than 1.2.3 have bugs that cause the libsndfile
 		# test suite to fail on MIPS, PowerPC and others.
 		# See: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=549899
 		PKG_CHECK_MOD_VERSION(VORBIS, vorbis >= 1.2.3, ac_cv_vorbis=yes, ac_cv_vorbis=no)
 		PKG_CHECK_MOD_VERSION(VORBISENC, vorbisenc >= 1.2.3, ac_cv_vorbisenc=yes, ac_cv_vorbisenc=no)
-		enable_external_libs=yes
 		fi
 
-	if test x$ac_cv_flac$ac_cv_ogg$ac_cv_vorbis$ac_cv_vorbisenc = "xyesyesyesyes" ; then
-		HAVE_EXTERNAL_LIBS=1
-		enable_external_libs=yes
-
-		EXTERNAL_CFLAGS="$FLAC_CFLAGS $OGG_CFLAGS $VORBIS_CFLAGS $VORBISENC_CFLAGS $SPEEX_CFLAGS"
-		EXTERNAL_LIBS="$FLAC_LIBS $OGG_LIBS $VORBIS_LIBS $VORBISENC_LIBS $SPEEX_LIBS "
-	else
-		echo
-		AC_MSG_WARN([[*** One or more of the external libraries (ie libflac, libogg and]])
-		AC_MSG_WARN([[*** libvorbis) is either missing (possibly only the development]])
-		AC_MSG_WARN([[*** headers) or is of an unsupported version.]])
-		AC_MSG_WARN([[***]])
-		AC_MSG_WARN([[*** Unfortunately, for ease of maintenance, the external libs]])
-		AC_MSG_WARN([[*** are an all or nothing affair.]])
-		echo
-		enable_external_libs=no
+	if test x$ac_cv_flac = xyes ; then
+		HAVE_LIBFLAC=1
 		fi
+	if test x$ac_cv_ogg = xyes ; then
+		HAVE_LIBOGG=1
+		fi
+	if test x$ac_cv_vorbis = xyes ; then
+		HAVE_LIBVORBIS=1
+		fi
+
+	EXTERNAL_CFLAGS="$FLAC_CFLAGS $OGG_CFLAGS $VORBIS_CFLAGS $VORBISENC_CFLAGS $SPEEX_CFLAGS"
+	EXTERNAL_LIBS="$FLAC_LIBS $OGG_LIBS $VORBIS_LIBS $VORBISENC_LIBS $SPEEX_LIBS "
 	fi
 
-AC_DEFINE_UNQUOTED([HAVE_EXTERNAL_LIBS], $HAVE_EXTERNAL_LIBS, [Will be set to 1 if flac, ogg and vorbis are available.])
+AC_DEFINE_UNQUOTED([HAVE_LIBFLAC], $HAVE_LIBFLAC, [Will be set to 1 if libflac is available.])
+AC_DEFINE_UNQUOTED([HAVE_LIBOGG], $HAVE_LIBOGG, [Will be set to 1 if libogg is available.])
+AC_DEFINE_UNQUOTED([HAVE_LIBVORBIS], $HAVE_LIBVORBIS, [Will be set to 1 if libvorbis is available.])
 
 #====================================================================================
 # Check for libsqlite3 (only used in regtest).
@@ -630,7 +648,9 @@ AC_SUBST(SHARED_VERSION_INFO)
 AC_SUBST(CLEAN_VERSION)
 AC_SUBST(WIN_RC_VERSION)
 
-AC_SUBST(HAVE_EXTERNAL_LIBS)
+AC_SUBST(HAVE_LIBFLAC)
+AC_SUBST(HAVE_LIBOGG)
+AC_SUBST(HAVE_LIBVORBIS)
 AC_SUBST(OS_SPECIFIC_CFLAGS)
 AC_SUBST(OS_SPECIFIC_LINKS)
 AC_SUBST(ALSA_LIBS)
@@ -674,7 +694,9 @@ AC_MSG_RESULT([
 
     Experimental code : ................... ${enable_experimental:-no}
     Using ALSA in example programs : ...... ${enable_alsa:-no}
-    External FLAC/Ogg/Vorbis : ............ ${enable_external_libs:-no}
+    External FLAC library : ............... ${enable_libflac:-yes}
+    External Ogg library : ................ ${enable_libogg:-yes}
+    External Vorbis library : ............. ${enable_libvorbis:-yes}
 ])
 
 if test -z "$PKG_CONFIG" ; then

--- a/doc/command.html
+++ b/doc/command.html
@@ -747,7 +747,7 @@ The SF_FORMAT_INFO struct is defined in &lt;sndfile.h&gt; as:
 </PRE>
 <P>
 When sf_command() is called with SF_GET_SIMPLE_FORMAT, the value of the format
-field should be the format number (ie 0 &lt;= format &lt;= count value obtained using
+field should be the format number (ie 0 &lt;= format &lt; count value obtained using
 SF_GET_SIMPLE_FORMAT_COUNT).
 </P>
 <P>

--- a/src/command.c
+++ b/src/command.c
@@ -55,7 +55,7 @@ static SF_FORMAT_INFO const simple_formats [] =
 		"CAF (Apple 16 bit PCM)", "caf"
 		},
 
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBFLAC
 	{	SF_FORMAT_FLAC | SF_FORMAT_PCM_16,
 		"FLAC 16 bit", "flac"
 		},
@@ -65,7 +65,7 @@ static SF_FORMAT_INFO const simple_formats [] =
 		"OKI Dialogic VOX ADPCM", "vox"
 		},
 
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBOGG && HAVE_LIBVORBIS
 	{	SF_FORMAT_OGG | SF_FORMAT_VORBIS,
 		"Ogg Vorbis (Xiph Foundation)", "oga"
 		},
@@ -121,7 +121,7 @@ static SF_FORMAT_INFO const major_formats [] =
 	{	SF_FORMAT_AU,		"AU (Sun/NeXT)", 						"au"	},
 	{	SF_FORMAT_AVR,		"AVR (Audio Visual Research)",			"avr"	},
 	{	SF_FORMAT_CAF,		"CAF (Apple Core Audio File)",			"caf"	},
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBFLAC
 	{	SF_FORMAT_FLAC,		"FLAC (Free Lossless Audio Codec)",		"flac"	},
 #endif
 	{	SF_FORMAT_HTK,		"HTK (HMM Tool Kit)",					"htk"	},
@@ -129,7 +129,7 @@ static SF_FORMAT_INFO const major_formats [] =
 	{	SF_FORMAT_MAT4,		"MAT4 (GNU Octave 2.0 / Matlab 4.2)",	"mat"	},
 	{	SF_FORMAT_MAT5,		"MAT5 (GNU Octave 2.1 / Matlab 5.0)",	"mat"	},
 	{	SF_FORMAT_MPC2K,	"MPC (Akai MPC 2k)",					"mpc"	},
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBOGG
 	{	SF_FORMAT_OGG,		"OGG (OGG Container format)",			"oga"	},
 #endif
 	{	SF_FORMAT_PAF,		"PAF (Ensoniq PARIS)", 					"paf"	},
@@ -201,7 +201,7 @@ static SF_FORMAT_INFO subtype_formats [] =
 	{	SF_FORMAT_DPCM_16,		"16 bit DPCM",			NULL 	},
 	{	SF_FORMAT_DPCM_8,		"8 bit DPCM",			NULL 	},
 
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBVORBIS
 	{	SF_FORMAT_VORBIS,		"Vorbis",				NULL 	},
 #endif
 

--- a/src/flac.c
+++ b/src/flac.c
@@ -29,7 +29,7 @@
 #include	"sndfile.h"
 #include	"common.h"
 
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBFLAC
 
 #include	<FLAC/stream_decoder.h>
 #include	<FLAC/stream_encoder.h>
@@ -1369,7 +1369,7 @@ flac_byterate (SF_PRIVATE *psf)
 } /* flac_byterate */
 
 
-#else /* HAVE_EXTERNAL_LIBS */
+#else /* HAVE_LIBFLAC */
 
 int
 flac_open	(SF_PRIVATE *psf)

--- a/src/ogg.c
+++ b/src/ogg.c
@@ -34,7 +34,7 @@
 #include "sfendian.h"
 #include "common.h"
 
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBOGG
 
 #include <ogg/ogg.h>
 
@@ -241,7 +241,7 @@ ogg_page_classify (SF_PRIVATE * psf, const ogg_page * og)
 	return 0 ;
 } /* ogg_page_classify */
 
-#else /* HAVE_EXTERNAL_LIBS */
+#else /* HAVE_LIBOGG */
 
 int
 ogg_open	(SF_PRIVATE *psf)

--- a/src/ogg_opus.c
+++ b/src/ogg_opus.c
@@ -34,7 +34,7 @@
 #include "sfendian.h"
 #include "common.h"
 
-#if (ENABLE_EXPERIMENTAL_CODE && HAVE_EXTERNAL_LIBS)
+#if (ENABLE_EXPERIMENTAL_CODE && HAVE_LIBOGG)
 
 #include <ogg/ogg.h>
 
@@ -137,7 +137,7 @@ ogg_opus_close (SF_PRIVATE * UNUSED (psf))
 } /* ogg_opus_close */
 
 
-#else /* ENABLE_EXPERIMENTAL_CODE && HAVE_EXTERNAL_LIBS */
+#else /* ENABLE_EXPERIMENTAL_CODE && HAVE_LIBOGG */
 
 int
 ogg_opus_open (SF_PRIVATE *psf)

--- a/src/ogg_pcm.c
+++ b/src/ogg_pcm.c
@@ -34,7 +34,7 @@
 #include "sfendian.h"
 #include "common.h"
 
-#if (ENABLE_EXPERIMENTAL_CODE && HAVE_EXTERNAL_LIBS)
+#if (ENABLE_EXPERIMENTAL_CODE && HAVE_LIBOGG)
 
 #include <ogg/ogg.h>
 
@@ -152,7 +152,7 @@ duration = audio_samples / rate
          = 3.947
 */
 
-#else /* ENABLE_EXPERIMENTAL_CODE && HAVE_EXTERNAL_LIBS */
+#else /* ENABLE_EXPERIMENTAL_CODE && HAVE_LIBOGG */
 
 int
 ogg_pcm_open (SF_PRIVATE *psf)

--- a/src/ogg_speex.c
+++ b/src/ogg_speex.c
@@ -34,7 +34,7 @@
 #include "sfendian.h"
 #include "common.h"
 
-#if (ENABLE_EXPERIMENTAL_CODE && HAVE_EXTERNAL_LIBS)
+#if (ENABLE_EXPERIMENTAL_CODE && HAVE_LIBOGG)
 
 #include <ogg/ogg.h>
 
@@ -413,7 +413,7 @@ duration = audio_samples / rate
 		 = 3.947
 */
 
-#else /* ENABLE_EXPERIMENTAL_CODE && HAVE_EXTERNAL_LIBS */
+#else /* ENABLE_EXPERIMENTAL_CODE && HAVE_LIBOGG */
 
 int
 ogg_speex_open (SF_PRIVATE *psf)

--- a/src/ogg_vorbis.c
+++ b/src/ogg_vorbis.c
@@ -68,7 +68,7 @@
 #include "sfendian.h"
 #include "common.h"
 
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBOGG && HAVE_LIBVORBIS
 
 #include <ogg/ogg.h>
 #include <vorbis/codec.h>
@@ -1166,7 +1166,7 @@ vorbis_length (SF_PRIVATE *psf)
 	return length ;
 } /* vorbis_length */
 
-#else /* HAVE_EXTERNAL_LIBS */
+#else /* HAVE_LIBVORBIS && HAVE_LIBOGG */
 
 int
 ogg_vorbis_open	(SF_PRIVATE *psf)

--- a/tests/compression_size_test.c
+++ b/tests/compression_size_test.c
@@ -178,21 +178,24 @@ main (int argc, char *argv [])
 		exit (0) ;
 		} ;
 
-	if (! HAVE_EXTERNAL_LIBS)
-	{	puts ("    No Ogg/Vorbis tests because Ogg/Vorbis support was not compiled in.") ;
-		return 0 ;
-	} ;
-
 	if (strcmp (argv [1], "all") == 0)
 		all_tests = 1 ;
 
-	if (all_tests || strcmp (argv [1], "vorbis") == 0)
+	if (! HAVE_LIBOGG || ! HAVE_LIBVORBIS)
+	{	puts ("    No Ogg/Vorbis tests because Ogg/Vorbis support was not compiled in.") ;
+		return 0 ;
+		}
+	else if (all_tests || strcmp (argv [1], "vorbis") == 0)
 	{	vorbis_test () ;
 		compression_size_test (SF_FORMAT_OGG | SF_FORMAT_VORBIS, "vorbis.oga") ;
 		tests ++ ;
 		} ;
 
-	if (all_tests || strcmp (argv [1], "flac") == 0)
+	if (! HAVE_LIBFLAC)
+	{	puts ("    No FLAC tests because FLAC support was not compiled in.") ;
+		return 0 ;
+		}
+	else if (all_tests || strcmp (argv [1], "flac") == 0)
 	{	compression_size_test (SF_FORMAT_FLAC | SF_FORMAT_PCM_16, "pcm16.flac") ;
 		tests ++ ;
 		} ;

--- a/tests/external_libs_test.c
+++ b/tests/external_libs_test.c
@@ -59,14 +59,15 @@ major_format_test (void)
 		have_ogg = info.format == SF_FORMAT_OGG ? 1 : have_ogg ;
 		} ;
 
-	if (HAVE_EXTERNAL_LIBS)
-	{	exit_if_true (have_flac == 0, "\n\nLine %d : FLAC should be available.\n\n", __LINE__) ;
-		exit_if_true (have_ogg == 0, "\n\nLine %d : Ogg/Vorbis should be available.\n\n", __LINE__) ;
-		}
+	if (HAVE_LIBFLAC)
+		exit_if_true (have_flac == 0, "\n\nLine %d : FLAC should be available.\n\n", __LINE__) ;
 	else
-	{	exit_if_true (have_flac, "\n\nLine %d : FLAC should not be available.\n\n", __LINE__) ;
+		exit_if_true (have_flac, "\n\nLine %d : FLAC should not be available.\n\n", __LINE__) ;
+
+	if (HAVE_LIBOGG)
+		exit_if_true (have_ogg == 0, "\n\nLine %d : Ogg/Vorbis should be available.\n\n", __LINE__) ;
+	else
 		exit_if_true (have_ogg, "\n\nLine %d : Ogg/Vorbis should not be available.\n\n", __LINE__) ;
-		} ;
 
 	puts ("ok") ;
 } /* major_format_test */
@@ -88,10 +89,10 @@ subtype_format_test (void)
 		have_vorbis = info.format == SF_FORMAT_VORBIS ? 1 : have_vorbis ;
 		} ;
 
-	if (HAVE_EXTERNAL_LIBS)
-		exit_if_true (have_vorbis == 0, "\n\nLine %d : Ogg/Vorbis should be available.\n\n", __LINE__) ;
+	if (HAVE_LIBVORBIS)
+		exit_if_true (have_vorbis == 0, "\n\nLine %d : Vorbis should be available.\n\n", __LINE__) ;
 	else
-		exit_if_true (have_vorbis, "\n\nLine %d : Ogg/Vorbis should not be available.\n\n", __LINE__) ;
+		exit_if_true (have_vorbis, "\n\nLine %d : Vorbis should not be available.\n\n", __LINE__) ;
 
 	puts ("ok") ;
 } /* subtype_format_test */
@@ -134,16 +135,16 @@ simple_format_test (void)
 
 		} ;
 
-	if (HAVE_EXTERNAL_LIBS)
-	{	exit_if_true (have_flac == 0, "\n\nLine %d : FLAC should be available.\n\n", __LINE__) ;
-		exit_if_true (have_ogg == 0, "\n\nLine %d : Ogg/Vorbis should be available.\n\n", __LINE__) ;
-		exit_if_true (have_vorbis == 0, "\n\nLine %d : Ogg/Vorbis should be available.\n\n", __LINE__) ;
-		}
+	if (HAVE_LIBFLAC)
+		exit_if_true (have_flac == 0, "\n\nLine %d : FLAC should be available.\n\n", __LINE__) ;
 	else
-	{	exit_if_true (have_flac, "\n\nLine %d : FLAC should not be available.\n\n", __LINE__) ;
-		exit_if_true (have_ogg, "\n\nLine %d : Ogg/Vorbis should not be available.\n\n", __LINE__) ;
-		exit_if_true (have_vorbis, "\n\nLine %d : Ogg/Vorbis should not be available.\n\n", __LINE__) ;
-		} ;
+		exit_if_true (have_flac, "\n\nLine %d : FLAC should not be available.\n\n", __LINE__) ;
+
+	/* simple_formats only includes Ogg+Vorbis together as a pair. */
+	if (HAVE_LIBOGG && HAVE_LIBVORBIS)
+		exit_if_true (have_ogg == 0 || have_vorbis == 0, "\n\nLine %d : Ogg/Vorbis should be available.\n\n", __LINE__) ;
+	else
+		exit_if_true (have_ogg && have_vorbis, "\n\nLine %d : Ogg/Vorbis should not be available.\n\n", __LINE__) ;
 
 	puts ("ok") ;
 } /* simple_format_test */

--- a/tests/floating_point_test.tpl
+++ b/tests/floating_point_test.tpl
@@ -113,11 +113,13 @@ main (int argc, char *argv [])
 	float_scaled_test	("alac_24.caf", allow_exit, SF_FALSE, SF_FORMAT_CAF | SF_FORMAT_ALAC_24, -153.0) ;
 	float_scaled_test	("alac_20.caf", allow_exit, SF_FALSE, SF_FORMAT_CAF | SF_FORMAT_ALAC_20, -125.0) ;
 
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBFLAC
 	float_scaled_test	("flac_8.flac", allow_exit, SF_FALSE, SF_FORMAT_FLAC | SF_FORMAT_PCM_S8, -39.0) ;
 	float_scaled_test	("flac_16.flac", allow_exit, SF_FALSE, SF_FORMAT_FLAC | SF_FORMAT_PCM_16, -87.0) ;
 	float_scaled_test	("flac_24.flac", allow_exit, SF_FALSE, SF_FORMAT_FLAC | SF_FORMAT_PCM_24, -138.0) ;
+#endif
 
+#if HAVE_LIBOGG && HAVE_LIBVORBIS
 	float_scaled_test	("vorbis.oga", allow_exit, SF_FALSE, SF_FORMAT_OGG | SF_FORMAT_VORBIS, -31.0) ;
 #endif
 
@@ -170,11 +172,13 @@ main (int argc, char *argv [])
 	double_scaled_test	("alac_24.caf", allow_exit, SF_FALSE, SF_FORMAT_CAF | SF_FORMAT_ALAC_24, -153.0) ;
 	double_scaled_test	("alac_32.caf", allow_exit, SF_FALSE, SF_FORMAT_CAF | SF_FORMAT_ALAC_32, -186.0) ;
 
-#if HAVE_EXTERNAL_LIBS
+#if HAVE_LIBFLAC
 	double_scaled_test	("flac_8.flac", allow_exit, SF_FALSE, SF_FORMAT_FLAC | SF_FORMAT_PCM_S8, -39.0) ;
 	double_scaled_test	("flac_16.flac", allow_exit, SF_FALSE, SF_FORMAT_FLAC | SF_FORMAT_PCM_16, -87.0) ;
 	double_scaled_test	("flac_24.flac", allow_exit, SF_FALSE, SF_FORMAT_FLAC | SF_FORMAT_PCM_24, -138.0) ;
+#endif
 
+#if HAVE_LIBOGG && HAVE_LIBVORBIS
 	double_scaled_test	("vorbis.oga", allow_exit, SF_FALSE, SF_FORMAT_OGG | SF_FORMAT_VORBIS, -29.0) ;
 #endif
 

--- a/tests/lossy_comp_test.c
+++ b/tests/lossy_comp_test.c
@@ -376,7 +376,7 @@ main (int argc, char *argv [])
 		} ;
 
 	if (do_all || strcmp (argv [1], "ogg_vorbis") == 0)
-	{	if (HAVE_EXTERNAL_LIBS)
+	{	if (HAVE_LIBOGG && HAVE_LIBVORBIS)
 		{	/* Don't do lcomp_test_XXX as the errors are too big. */
 			sdlcomp_test_short	("vorbis.oga", SF_FORMAT_OGG | SF_FORMAT_VORBIS, 1, 0.30) ;
 			sdlcomp_test_int	("vorbis.oga", SF_FORMAT_OGG | SF_FORMAT_VORBIS, 1, 0.30) ;

--- a/tests/misc_test.c
+++ b/tests/misc_test.c
@@ -226,7 +226,7 @@ zero_data_test (const char *filename, int format)
 
 	switch (format & SF_FORMAT_TYPEMASK)
 	{	case SF_FORMAT_OGG :
-			if (HAVE_EXTERNAL_LIBS == 0)
+			if (!HAVE_LIBOGG || !HAVE_LIBVORBIS)
 				return ;
 			break ;
 		default :

--- a/tests/ogg_test.c
+++ b/tests/ogg_test.c
@@ -328,7 +328,7 @@ ogg_stereo_seek_test (const char * filename, int format)
 int
 main (void)
 {
-	if (HAVE_EXTERNAL_LIBS)
+	if (HAVE_LIBOGG && HAVE_LIBVORBIS)
 	{	ogg_short_test () ;
 		ogg_int_test () ;
 		ogg_float_test () ;

--- a/tests/string_test.c
+++ b/tests/string_test.c
@@ -103,7 +103,7 @@ main (int argc, char *argv [])
 		} ;
 
 	if (do_all || ! strcmp (argv [1], "flac"))
-	{	if (HAVE_EXTERNAL_LIBS)
+	{	if (HAVE_LIBFLAC)
 			string_start_test ("strings.flac", SF_FORMAT_FLAC) ;
 		else
 			puts ("    No FLAC tests because FLAC support was not compiled in.") ;
@@ -111,7 +111,7 @@ main (int argc, char *argv [])
 		} ;
 
 	if (do_all || ! strcmp (argv [1], "ogg"))
-	{	if (HAVE_EXTERNAL_LIBS)
+	{	if (HAVE_LIBOGG && HAVE_LIBVORBIS)
 			string_start_test ("vorbis.oga", SF_FORMAT_OGG) ;
 		else
 			puts ("    No Ogg/Vorbis tests because Ogg/Vorbis support was not compiled in.") ;

--- a/tests/write_read_test.tpl
+++ b/tests/write_read_test.tpl
@@ -366,7 +366,7 @@ main (int argc, char **argv)
 		} ;
 
 	if (do_all || ! strcmp (argv [1], "flac"))
-	{	if (HAVE_EXTERNAL_LIBS)
+	{	if (HAVE_LIBFLAC)
 		{	pcm_test_char	("char.flac"	, SF_FORMAT_FLAC | SF_FORMAT_PCM_S8, SF_TRUE) ;
 			pcm_test_short	("short.flac"	, SF_FORMAT_FLAC | SF_FORMAT_PCM_16, SF_TRUE) ;
 			pcm_test_24bit	("24bit.flac"	, SF_FORMAT_FLAC | SF_FORMAT_PCM_24, SF_TRUE) ;


### PR DESCRIPTION
Previously you could only configure all of libflac, libogg and libvorbis
or none of them. This change separates out the detection/enabling/disabling
of them into --enable-libflac --enable-libogg and --enable-vorbis.

Apart from being useful in itself, this makes it possible to
add other formats via external libraries (libopus, libspeex ...)
without insisting that all of the external libraries be available or none.

We keep the old option --disable-external-libs because it is used in the
build scripts for OpenWRT, OpenEmbedded and others.

See the discussion in https://github.com/erikd/libsndfile/issues/15