### PR TITLE
Line endings issue under Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.ac text eol=lf
+*.am text eol=lf
+*.m4 text eol=lf
+*.pc text eol=lf
+*.spec text eol=lf
+*.sh text eol=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.h text

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@
 .DS_Store
 .deps
 .dirstamp
-.git*
 .libs
 Build/
 CMake/config.h.in


### PR DESCRIPTION
This commit and .gittatribures file and fixes incorrect line endings handling under Windows (MinGW).

autoreconf fails with strange error:

    " is already registred with AC_CONFIG_FILES

`dos2unix` helps is this case.

The reason is that autoreconf expects Unix line endings (LF), but Git under Windows uses CRLF.

After fix Git under Windows will respect LF line endings for Unix-specific files.