### PR TITLE
Ignore config.h.in~ file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ src/Symbols.os2
 src/Symbols.static
 src/config.h
 src/config.h.in
+src/config.h.in~
 src/libsndfile.so*
 src/libsndfile-1.def
 src/sndfile.h


### PR DESCRIPTION
config.h.in~ is autogenerated file, no need to track it.