### PR TITLE
Use INT64_C macro if available

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -41,7 +41,9 @@
 #error "This code is not designed to be compiled with a C++ compiler."
 #endif
 
-#if (SIZEOF_LONG == 8)
+#ifdef INT64_C
+#	define	SF_PLATFORM_S64(x)		INT64_C(x)
+#elif (SIZEOF_LONG == 8)
 #	define	SF_PLATFORM_S64(x)		x##l
 #elif (SIZEOF_LONG_LONG == 8)
 #	define	SF_PLATFORM_S64(x)		x##ll


### PR DESCRIPTION
If `stdint.h` header is available, use standard `INT64_C` macro to declare 64-bit integer constants.

This makes code more portable.