### PR TITLE
Use io.h as partial replacement of unistd.h

### DIFF
--- a/src/sf_unistd.h
+++ b/src/sf_unistd.h
@@ -16,6 +16,12 @@
 ** Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
+/* Microsoft declares some 'unistd.h' functions in 'io.h'. */
+
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif
+
 /* Some defines that microsoft 'forgot' to implement. */
 
 #ifndef S_IRWXU


### PR DESCRIPTION
This fixes some aspects of missing `unistd.h` header in  MSVC.
`sf_unistd.h` defines some useful constants, now it also includes
`io.h`, where MSVC declares [required](https://github.com/erikd/libsndfile/blob/master/src/common.c#L1702) `access` function.