### PR TITLE
Properly select MSVC version when define SF_COUNT_MAX in sndfile.h #155

### DIFF
--- a/src/sndfile.h.in
+++ b/src/sndfile.h.in
@@ -333,7 +333,7 @@ typedef	struct SNDFILE_tag	SNDFILE ;
 ** and the Microsoft compiler.
 */
 
-#if (defined (_MSCVER) || defined (_MSC_VER))
+#if (defined (_MSCVER) || defined (_MSC_VER) && (_MSC_VER < 1310))
 typedef __int64		sf_count_t ;
 #define SF_COUNT_MAX		0x7fffffffffffffffi64
 #else


### PR DESCRIPTION
Miscosoft C compiler supports `long long` and `LL` 64-bit integer-suffix [since Visual Studio 2003](https://msdn.microsoft.com/en-us/library/00a1awxf(v=vs.71).aspx).

`_MSCVER` macro is dropped because i didn't find any information about it in [MSDN](https://msdn.microsoft.com/en-us/library/b0084kay.aspx).

Mybe it's better just do not support this MSVC-specific code, these compiler versions are really old.

I think it makes no sense to add related detection code in CMake, due to lack of normal support of C in MSVC before 2013, which supports `long long` and `LL`.