### PR TITLE
configure.ac: check for inline #157

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,9 +133,9 @@ AC_ARG_ENABLE(test-coverage,
 	AC_HELP_STRING([--enable-test-coverage], [enable test coverage]))
 AM_CONDITIONAL([ENABLE_TEST_COVERAGE], [test "$enable_test_coverage" = yes])
 
-#====================================================================================
-# Check types and their sizes.
+# Checks for typedefs, structures, and compiler characteristics.
 
+AC_C_INLINE
 AC_CHECK_SIZEOF(wchar_t,4)
 AC_CHECK_SIZEOF(short,2)
 AC_CHECK_SIZEOF(int,4)


### PR DESCRIPTION
If the C compiler supports the keyword inline, do nothing. Otherwise
define inline to __inline__ or __inline if it accepts one of those,
otherwise define inline to be empty.