### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+insert_final_newline = true
+
+[*.{h,hpp,c,tpl,def}]
+indent_style = tab
+tab_width = 4
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ EXTRA_DIST = libsndfile.spec.in sndfile.pc.in Scripts/android-configure.sh \
 	Scripts/linux-to-win-cross-configure.sh Scripts/build-test-tarball.mk.in \
     CMakeLists.txt CMake/autogen.cmake CMake/build.cmake CMake/check.cmake \
 	CMake/compiler_is_gcc.c CMake/external_libs.cmake CMake/file.cmake \
-	CMake/have_decl_s_irgrp.c CMake/libsndfile.cmake
+	CMake/have_decl_s_irgrp.c CMake/libsndfile.cmake .editorconfig
 
 
 CLEANFILES = *~


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) helps developers define and maintain consistent coding styles between different editors and IDEs.
