### PR TITLE
Cmake clipping test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option (BUILD_STATIC_LIBS "Build static libraries" ON)
 option (BUILD_SHARED_LIBS "Build shared libraries" ON)
 option (DISABLE_EXTERNAL_LIBS "Disable use of FLAC, Ogg and Vorbis" OFF)
 option (ENABLE_EXPERIMENTAL "Enable experimental code" OFF)
+option (DISABLE_CPU_CLIP "Disable tricky cpu specific clipper" OFF)
 
 if ((NOT BUILD_STATIC_LIBS) AND (NOT BUILD_SHARED_LIBS))
 message (WARNING "
@@ -50,6 +51,7 @@ add_feature_info(ENABLE_TESTING ENABLE_TESTING "build tests")
 add_feature_info(DISABLE_EXTERNAL_LIBS DISABLE_EXTERNAL_LIBS "disable use of FLAC, Ogg and Vorbis")
 add_feature_info(ENABLE_EXPERIMENTAL ENABLE_EXPERIMENTAL "enable experimental code")
 add_feature_info(BUILD_TESTING BUILD_TESTING "build tests")
+add_feature_info(DISABLE_CPU_CLIP DISABLE_CPU_CLIP "Disable tricky cpu specific clipper")
 
 set_package_properties(Ogg PROPERTIES TYPE RECOMMENDED
 	URL "www.xiph.org/ogg/"

--- a/cmake/ClipMode.cmake
+++ b/cmake/ClipMode.cmake
@@ -1,0 +1,92 @@
+include (CheckCSourceRuns)
+include (CMakePushCheckState)
+
+macro (CLIP_MODE)
+
+	set (CLIP_MODE_POSITIVE_MESSAGE "Target processor clips on positive float to int conversion")
+	set (CLIP_MODE_NEGATIVE_MESSAGE "Target processor clips on negative float to int conversion")
+
+	message (STATUS "Checking processor clipping capabilities...")
+
+	if (CMAKE_CROSSCOMPILING)
+
+		set (CLIP_MSG "disabled")
+		set (CPU_CLIPS_POSITIVE FALSE CACHE BOOL ${CLIP_MODE_POSITIVE_MESSAGE})
+		set (CPU_CLIPS_NEGATIVE FALSE CACHE BOOL ${CLIP_MODE_NEGATIVE_MESSAGE})
+
+	else (NOT CMAKE_CROSSCOMPILING)
+
+		cmake_push_check_state ()
+		
+		set (CMAKE_REQUIRED_QUIET TRUE)
+		if (LIBM_REQUIRED)
+			set (CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${M_LIBRARY})
+		endif ()
+		
+		check_c_source_runs (
+		"
+		#define	_ISOC9X_SOURCE	1
+		#define _ISOC99_SOURCE	1
+		#define	__USE_ISOC99	1
+		#define __USE_ISOC9X	1
+		#include <math.h>
+		int main (void)
+		{	double	fval ;
+			int k, ival ;
+
+			fval = 1.0 * 0x7FFFFFFF ;
+			for (k = 0 ; k < 100 ; k++)
+			{	ival = (lrint (fval)) >> 24 ;
+				if (ival != 127)
+					return 1 ;
+			
+				fval *= 1.2499999 ;
+				} ;
+			
+				return 0 ;
+			}
+		"
+		CPU_CLIPS_POSITIVE)
+		
+		check_c_source_runs (
+		"
+		#define	_ISOC9X_SOURCE	1
+		#define _ISOC99_SOURCE	1
+		#define	__USE_ISOC99	1
+		#define __USE_ISOC9X	1
+		#include <math.h>
+		int main (void)
+		{	double	fval ;
+			int k, ival ;
+
+			fval = -8.0 * 0x10000000 ;
+			for (k = 0 ; k < 100 ; k++)
+			{	ival = (lrint (fval)) >> 24 ;
+				if (ival != -128)
+					return 1 ;
+			
+				fval *= 1.2499999 ;
+				} ;
+			
+				return 0 ;
+			}
+		"
+		CPU_CLIPS_NEGATIVE)
+
+		cmake_pop_check_state ()
+
+		if (CPU_CLIPS_POSITIVE AND (NOT CPU_CLIPS_NEGATIVE))
+			set (CLIP_MSG "positive")
+		elseif (CPU_CLIPS_NEGATIVE AND (NOT CPU_CLIPS_POSITIVE))
+			set (CLIP_MSG "negative")
+		elseif (CPU_CLIPS_POSITIVE AND CPU_CLIPS_NEGATIVE)
+			set (CLIP_MSG "both")
+		else ()
+			set (CLIP_MSG "none")
+		endif ()
+
+	endif (CMAKE_CROSSCOMPILING)
+
+	message (STATUS "Checking processor clipping capabilities... ${CLIP_MSG}")
+
+endmacro (CLIP_MODE)

--- a/cmake/SndFileChecks.cmake
+++ b/cmake/SndFileChecks.cmake
@@ -6,6 +6,7 @@ include (CheckTypeSize)
 include (TestBigEndian)
 
 include (TestInline)
+include (ClipMode)
 
 if (WIN32)
     set(TYPEOF_SF_COUNT_T __int64)
@@ -188,3 +189,6 @@ if (ENABLE_EXPERIMENTAL)
 endif ()
 
 test_inline ()
+if (NOT DISABLE_CPU_CLIP)
+	clip_mode ()
+endif ()


### PR DESCRIPTION
This PR adds clipping test, just like Autotools toolchain's one.

If cross-compiling, test will not give correct results, so `CPU_CLIPS_POSITIVE` and `CPU_CLIPS_NEGATIVE` values are set to `0` in this case and you can change them in CMake GUI.

`DISABLE_CPU_CLIP` option can be used to disable this feature completely.