### PR TITLE
Cmake tests part 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,6 +746,13 @@ if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
 	target_link_libraries(compression_size_test PRIVATE ${M_LIBRARY})
 endif ()
 
+set (ogg_test_SOURCES tests/ogg_test.c tests/utils.c)
+add_executable (ogg_test ${ogg_test_SOURCES})
+target_link_libraries (ogg_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(ogg_test PRIVATE ${M_LIBRARY})
+endif ()
+
 ### aiff-tests
 
 add_test (write_read_test_aiff write_read_test aiff)
@@ -905,4 +912,11 @@ add_test (misc_test_mpc2k misc_test mpc2k)
 add_test (write_read_test_flac write_read_test flac)
 add_test (compression_size_test_flac compression_size_test flac)
 add_test (string_test_flac string_test flac)
+
+### vorbis-tests
+add_test (ogg_test ogg_test)
+add_test (compression_size_test_vorbis compression_size_test vorbis)
+add_test (lossy_comp_test_ogg_vorbis lossy_comp_test ogg_vorbis)
+add_test (string_test_ogg string_test ogg)
+add_test (misc_test_ogg misc_test ogg)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -769,3 +769,14 @@ add_test (chunk_test_caf chunk_test caf)
 add_test (string_test_caf string_test caf)
 add_test (long_read_write_test_alac long_read_write_test alac)
 
+### w64-tests
+
+add_test (write_read_test_w64 write_read_test w64)
+add_test (lossy_comp_test_w64_ima lossy_comp_test w64_ima)
+add_test (lossy_comp_test_w64_msadpcm lossy_comp_test w64_msadpcm)
+add_test (lossy_comp_test_w64_ulaw lossy_comp_test w64_ulaw)
+add_test (lossy_comp_test_w64_alaw lossy_comp_test w64_alaw)
+add_test (lossy_comp_test_w64_gsm610 lossy_comp_test w64_gsm610)
+add_test (header_test_w64 header_test w64)
+add_test (misc_test_w64 misc_test w64)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -628,6 +628,16 @@ add_test (locale_test locale_test)
 
 # TODO
 
+### cpp_test
+
+set (cpp_test_SOURCES tests/cpp_test.cc tests/utils.c)
+add_executable (cpp_test ${cpp_test_SOURCES})
+target_link_libraries (cpp_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(cpp_test PRIVATE ${M_LIBRARY})
+endif ()
+add_test (cpp_test cpp_test)
+
 ### external_libs_test
 
 set (external_libs_test_SOURCES tests/external_libs_test.c tests/utils.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -855,3 +855,8 @@ add_test (write_read_test_mat4 write_read_test mat4)
 add_test (header_test_mat4 header_test mat4)
 add_test (misc_test_mat4 misc_test mat4)
 
+### mat5-tests
+add_test (write_read_test_mat5 write_read_test mat5)
+add_test (header_test_mat5 header_test mat5)
+add_test (misc_test_mat5 misc_test mat5)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -824,3 +824,8 @@ add_test (write_read_test_paf write_read_test paf)
 add_test (header_test_paf header_test paf)
 add_test (misc_test_paf misc_test paf)
 
+### svx-tests
+add_test (write_read_test_svx write_read_test svx)
+add_test (header_test_svx header_test svx)
+add_test (misc_test_svx misc_test svx)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,6 +739,13 @@ if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
 	target_link_libraries(raw_test PRIVATE ${M_LIBRARY})
 endif ()
 
+set (compression_size_test_SOURCES tests/compression_size_test.c tests/utils.c)
+add_executable (compression_size_test ${compression_size_test_SOURCES})
+target_link_libraries (compression_size_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(compression_size_test PRIVATE ${M_LIBRARY})
+endif ()
+
 ### aiff-tests
 
 add_test (write_read_test_aiff write_read_test aiff)
@@ -893,4 +900,9 @@ add_test (lossy_comp_test_wve lossy_comp_test wve)
 add_test (write_read_test_mpc2k write_read_test mpc2k)
 add_test (header_test_mpc2k header_test mpc2k)
 add_test (misc_test_mpc2k misc_test mpc2k)
+
+### flac-tests
+add_test (write_read_test_flac write_read_test flac)
+add_test (compression_size_test_flac compression_size_test flac)
+add_test (string_test_flac string_test flac)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,3 +819,8 @@ add_test (lossy_comp_test_raw_gsm610 lossy_comp_test raw_gsm610)
 add_test (lossy_comp_test_vox_adpcm lossy_comp_test vox_adpcm)
 add_test (raw_test raw_test)
 
+### paf-tests
+add_test (write_read_test_paf write_read_test paf)
+add_test (header_test_paf header_test paf)
+add_test (misc_test_paf misc_test paf)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,3 +659,82 @@ endif ()
 add_test (channel_test channel_test)
 
 endif ()
+
+### common test executables
+
+set (write_read_test_SOURCES tests/utils.c tests/generate.c tests/write_read_test.c)
+add_executable (write_read_test ${write_read_test_SOURCES})
+target_link_libraries (write_read_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(write_read_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (lossy_comp_test_SOURCES tests/utils.c tests/lossy_comp_test.c)
+add_executable (lossy_comp_test ${lossy_comp_test_SOURCES})
+target_link_libraries (lossy_comp_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(lossy_comp_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (peak_chunk_test_SOURCES tests/peak_chunk_test.c tests/utils.c)
+add_executable (peak_chunk_test ${peak_chunk_test_SOURCES})
+target_link_libraries (peak_chunk_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(peak_chunk_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (header_test_SOURCES tests/header_test.c tests/utils.c)
+add_executable (header_test ${header_test_SOURCES})
+target_link_libraries (header_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(header_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (misc_test_SOURCES tests/misc_test.c tests/utils.c)
+add_executable (misc_test ${misc_test_SOURCES})
+target_link_libraries (misc_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(misc_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (string_test_SOURCES tests/string_test.c tests/utils.c)
+add_executable (string_test ${string_test_SOURCES})
+target_link_libraries (string_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(string_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (multi_file_test_SOURCES tests/multi_file_test.c tests/utils.c)
+add_executable (multi_file_test ${multi_file_test_SOURCES})
+target_link_libraries (multi_file_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(multi_file_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (aiff_rw_test_SOURCES tests/utils.c tests/aiff_rw_test.c)
+add_executable (aiff_rw_test ${aiff_rw_test_SOURCES})
+target_link_libraries (aiff_rw_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(aiff_rw_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (chunk_test_SOURCES tests/chunk_test.c tests/utils.c)
+add_executable (chunk_test ${chunk_test_SOURCES})
+target_link_libraries (chunk_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(chunk_test PRIVATE ${M_LIBRARY})
+endif ()
+
+### aiff-tests
+
+add_test (write_read_test_aiff write_read_test aiff)
+add_test (lossy_comp_test_aiff_ulaw lossy_comp_test aiff_ulaw)
+add_test (lossy_comp_test_aiff_alaw lossy_comp_test aiff_alaw)
+add_test (lossy_comp_test_aiff_gsm610 lossy_comp_test aiff_gsm610)
+add_test (peak_chunk_test_aiff peak_chunk_test aiff)
+add_test (header_test_aiff header_test aiff)
+add_test (misc_test_aiff misc_test aiff)
+add_test (string_test_aiff string_test aiff)
+add_test (multi_file_test_aiff multi_file_test aiff)
+add_test (aiff_rw_test aiff_rw_test)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,3 +796,12 @@ add_test (lossy_comp_test_w64_gsm610 lossy_comp_test w64_gsm610)
 add_test (header_test_w64 header_test w64)
 add_test (misc_test_w64 misc_test w64)
 
+### rf64-tests
+
+add_test (write_read_test_rf64 write_read_test rf64)
+add_test (header_test_rf64 header_test rf64)
+add_test (misc_test_rf64 misc_test rf64)
+add_test (string_test_rf64 string_test rf64)
+add_test (peak_chunk_test_rf64 peak_chunk_test rf64)
+add_test (chunk_test_rf64 chunk_test rf64)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,3 +883,6 @@ add_test (write_read_test_sds write_read_test sds)
 add_test (header_test_sds header_test sds)
 add_test (misc_test_sds misc_test sds)
 
+# sd2-tests
+add_test (write_read_test_sd2 write_read_test sd2)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -836,3 +836,10 @@ add_test (lossy_comp_test_nist_alaw lossy_comp_test nist_alaw)
 add_test (header_test_nist header_test nist)
 add_test (misc_test_nist misc_test nist)
 
+### ircam-tests
+add_test (write_read_test_ircam write_read_test ircam)
+add_test (lossy_comp_test_ircam_ulaw lossy_comp_test ircam_ulaw)
+add_test (lossy_comp_test_ircam_alaw lossy_comp_test ircam_alaw)
+add_test (header_test_ircam header_test ircam)
+add_test (misc_test_ircam misc_test ircam)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -868,3 +868,8 @@ add_test (misc_test_pvf misc_test pvf)
 ### xi-tests
 add_test (lossy_comp_test_xi_dpcm lossy_comp_test xi_dpcm)
 
+### htk-tests
+add_test (write_read_test_htk write_read_test htk)
+add_test (header_test_htk header_test htk)
+add_test (misc_test_htk misc_test htk)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -850,3 +850,8 @@ add_test (lossy_comp_test_voc_alaw lossy_comp_test voc_alaw)
 add_test (header_test_voc header_test voc)
 add_test (misc_test_voc misc_test voc)
 
+### mat4-tests
+add_test (write_read_test_mat4 write_read_test mat4)
+add_test (header_test_mat4 header_test mat4)
+add_test (misc_test_mat4 misc_test mat4)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,6 +753,41 @@ if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
 	target_link_libraries(ogg_test PRIVATE ${M_LIBRARY})
 endif ()
 
+set (stdin_test_SOURCES tests/stdin_test.c tests/utils.c)
+add_executable (stdin_test ${stdin_test_SOURCES})
+target_link_libraries (stdin_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(stdin_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (stdout_test_SOURCES tests/stdout_test.c)
+add_executable (stdout_test ${stdout_test_SOURCES})
+target_link_libraries (stdout_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(stdout_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (stdio_test_SOURCES tests/stdio_test.c tests/utils.c)
+add_executable (stdio_test ${stdio_test_SOURCES})
+target_link_libraries (stdio_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(stdio_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (pipe_test_SOURCES tests/pipe_test.c tests/utils.c)
+add_executable (pipe_test ${pipe_test_SOURCES})
+target_link_libraries (pipe_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(pipe_test PRIVATE ${M_LIBRARY})
+endif ()
+
+set (virtual_io_test_SOURCES tests/virtual_io_test.c tests/utils.c)
+add_executable (virtual_io_test ${virtual_io_test_SOURCES})
+target_link_libraries (virtual_io_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(virtual_io_test PRIVATE ${M_LIBRARY})
+endif ()
+
 ### aiff-tests
 
 add_test (write_read_test_aiff write_read_test aiff)
@@ -919,4 +954,9 @@ add_test (compression_size_test_vorbis compression_size_test vorbis)
 add_test (lossy_comp_test_ogg_vorbis lossy_comp_test ogg_vorbis)
 add_test (string_test_ogg string_test ogg)
 add_test (misc_test_ogg misc_test ogg)
+
+### io-tests
+add_test (stdio_test stdio_test)
+add_test (pipe_test pipe_test)
+add_test (virtual_io_test virtual_io_test)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -886,3 +886,6 @@ add_test (misc_test_sds misc_test sds)
 # sd2-tests
 add_test (write_read_test_sd2 write_read_test sd2)
 
+### wve-tests
+add_test (lossy_comp_test_wve lossy_comp_test wve)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,6 +746,17 @@ add_test (string_test_aiff string_test aiff)
 add_test (multi_file_test_aiff multi_file_test aiff)
 add_test (aiff_rw_test aiff_rw_test)
 
+### au-tests
+
+add_test (write_read_test_au write_read_test au)
+add_test (lossy_comp_test_au_ulaw lossy_comp_test au_ulaw)
+add_test (lossy_comp_test_au_alaw lossy_comp_test au_alaw)
+add_test (lossy_comp_test_au_g721 lossy_comp_test au_g721)
+add_test (lossy_comp_test_au_g723 lossy_comp_test au_g723)
+add_test (header_test_au header_test au)
+add_test (misc_test_au misc_test au)
+add_test (multi_file_test_au multi_file_test au)
+
 ### caf-tests
 
 add_test (write_read_test_caf write_read_test caf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -829,3 +829,10 @@ add_test (write_read_test_svx write_read_test svx)
 add_test (header_test_svx header_test svx)
 add_test (misc_test_svx misc_test svx)
 
+### nist-tests
+add_test (write_read_test_nist write_read_test nist)
+add_test (lossy_comp_test_nist_ulaw lossy_comp_test nist_ulaw)
+add_test (lossy_comp_test_nist_alaw lossy_comp_test nist_alaw)
+add_test (header_test_nist header_test nist)
+add_test (misc_test_nist misc_test nist)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -878,3 +878,8 @@ add_test (write_read_test_avr write_read_test avr)
 add_test (header_test_avr header_test avr)
 add_test (misc_test_avr misc_test avr)
 
+### sds-tests
+add_test (write_read_test_sds write_read_test sds)
+add_test (header_test_sds header_test sds)
+add_test (misc_test_sds misc_test sds)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -769,6 +769,22 @@ add_test (chunk_test_caf chunk_test caf)
 add_test (string_test_caf string_test caf)
 add_test (long_read_write_test_alac long_read_write_test alac)
 
+# wav-tests
+add_test (write_read_test_wav write_read_test wav)
+add_test (lossy_comp_test_wav_pcm lossy_comp_test wav_pcm)
+add_test (lossy_comp_test_wav_ima lossy_comp_test wav_ima)
+add_test (lossy_comp_test_wav_msadpcm lossy_comp_test wav_msadpcm)
+add_test (lossy_comp_test_wav_ulaw lossy_comp_test wav_ulaw)
+add_test (lossy_comp_test_wav_alaw lossy_comp_test wav_alaw)
+add_test (lossy_comp_test_wav_gsm610 lossy_comp_test wav_gsm610)
+add_test (lossy_comp_test_wav_g721 lossy_comp_test wav_g721)
+add_test (peak_chunk_test_wav peak_chunk_test wav)
+add_test (header_test_wav header_test wav)
+add_test (misc_test_wav misc_test wav)
+add_test (string_test_wav string_test wav)
+add_test (multi_file_test_wav multi_file_test wav)
+add_test (chunk_test_wav chunk_test wav)
+
 ### w64-tests
 
 add_test (write_read_test_w64 write_read_test w64)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -860,3 +860,8 @@ add_test (write_read_test_mat5 write_read_test mat5)
 add_test (header_test_mat5 header_test mat5)
 add_test (misc_test_mat5 misc_test mat5)
 
+### pvf-tests
+add_test (write_read_test_pvf write_read_test pvf)
+add_test (header_test_pvf header_test pvf)
+add_test (misc_test_pvf misc_test pvf)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,3 +843,10 @@ add_test (lossy_comp_test_ircam_alaw lossy_comp_test ircam_alaw)
 add_test (header_test_ircam header_test ircam)
 add_test (misc_test_ircam misc_test ircam)
 
+### voc-tests
+add_test (write_read_test_voc write_read_test voc)
+add_test (lossy_comp_test_voc_ulaw lossy_comp_test voc_ulaw)
+add_test (lossy_comp_test_voc_alaw lossy_comp_test voc_alaw)
+add_test (header_test_voc header_test voc)
+add_test (misc_test_voc misc_test voc)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,6 +732,12 @@ if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
 	target_link_libraries(long_read_write_test PRIVATE ${M_LIBRARY})
 endif ()
 
+set (raw_test_SOURCES tests/raw_test.c tests/utils.c)
+add_executable (raw_test ${raw_test_SOURCES})
+target_link_libraries (raw_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(raw_test PRIVATE ${M_LIBRARY})
+endif ()
 
 ### aiff-tests
 
@@ -804,4 +810,12 @@ add_test (misc_test_rf64 misc_test rf64)
 add_test (string_test_rf64 string_test rf64)
 add_test (peak_chunk_test_rf64 peak_chunk_test rf64)
 add_test (chunk_test_rf64 chunk_test rf64)
+
+### raw-tests
+add_test (write_read_test_raw write_read_test raw)
+add_test (lossy_comp_test_raw_ulaw lossy_comp_test raw_ulaw)
+add_test (lossy_comp_test_raw_alaw lossy_comp_test raw_alaw)
+add_test (lossy_comp_test_raw_gsm610 lossy_comp_test raw_gsm610)
+add_test (lossy_comp_test_vox_adpcm lossy_comp_test vox_adpcm)
+add_test (raw_test raw_test)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,3 +873,8 @@ add_test (write_read_test_htk write_read_test htk)
 add_test (header_test_htk header_test htk)
 add_test (misc_test_htk misc_test htk)
 
+### avr-tests
+add_test (write_read_test_avr write_read_test avr)
+add_test (header_test_avr header_test avr)
+add_test (misc_test_avr misc_test avr)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -865,3 +865,6 @@ add_test (write_read_test_pvf write_read_test pvf)
 add_test (header_test_pvf header_test pvf)
 add_test (misc_test_pvf misc_test pvf)
 
+### xi-tests
+add_test (lossy_comp_test_xi_dpcm lossy_comp_test xi_dpcm)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,6 +798,16 @@ if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
 	target_link_libraries(virtual_io_test PRIVATE ${M_LIBRARY})
 endif ()
 
+### g72x_test
+
+set (g72x_test_SOURCES src/G72x/g72x_test.c ${libg72x_SOURCES})
+add_executable (g72x_test ${g72x_test_SOURCES})
+target_link_libraries (g72x_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(g72x_test PRIVATE ${M_LIBRARY})
+endif ()
+add_test (g72x_test g72x_test all)
+
 ### aiff-tests
 
 add_test (write_read_test_aiff write_read_test aiff)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,3 +889,8 @@ add_test (write_read_test_sd2 write_read_test sd2)
 ### wve-tests
 add_test (lossy_comp_test_wve lossy_comp_test wve)
 
+### mpc2k-tests
+add_test (write_read_test_mpc2k write_read_test mpc2k)
+add_test (header_test_mpc2k header_test mpc2k)
+add_test (misc_test_mpc2k misc_test mpc2k)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,6 +725,14 @@ if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
 	target_link_libraries(chunk_test PRIVATE ${M_LIBRARY})
 endif ()
 
+set (long_read_write_test_SOURCES tests/long_read_write_test.c tests/utils.c)
+add_executable (long_read_write_test ${long_read_write_test_SOURCES})
+target_link_libraries (long_read_write_test PRIVATE ${SNDFILE_TARGET})
+if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	target_link_libraries(long_read_write_test PRIVATE ${M_LIBRARY})
+endif ()
+
+
 ### aiff-tests
 
 add_test (write_read_test_aiff write_read_test aiff)
@@ -737,4 +745,16 @@ add_test (misc_test_aiff misc_test aiff)
 add_test (string_test_aiff string_test aiff)
 add_test (multi_file_test_aiff multi_file_test aiff)
 add_test (aiff_rw_test aiff_rw_test)
+
+### caf-tests
+
+add_test (write_read_test_caf write_read_test caf)
+add_test (lossy_comp_test_caf_ulaw lossy_comp_test caf_ulaw)
+add_test (lossy_comp_test_caf_alaw lossy_comp_test caf_alaw)
+add_test (header_test_caf header_test caf)
+add_test (peak_chunk_test_caf peak_chunk_test caf)
+add_test (misc_test_caf misc_test caf)
+add_test (chunk_test_caf chunk_test caf)
+add_test (string_test_caf string_test caf)
+add_test (long_read_write_test_alac long_read_write_test alac)
 


### PR DESCRIPTION
Bunch of tests was added, see individual commits.

CMake's [add_test()](https://cmake.org/cmake/help/v3.0/command/add_test.html) command allows only one command per test, so there are multiple command invocations one by one. I guess it is possible to group them, but i didn't find a proper way to do this. It is not critical, tests works for now.

`win32_ordinal_test` is not implemented yet, it has hardcoded paths to `libsndfile-1.def`, but CMake can be invoked from any location, so this test will fail. I think we need to add optional path parameter to `win32_ordinal_test`.

I'm not sure what is purpose of `pedantic-header-test.sh`, as i think my `sf_version_test` does the same?

May be something other is missing, if you find something i will add it.
