### PR TITLE
tests: Fix typos in fixes for MSVC

### DIFF
--- a/src/test_main.c
+++ b/src/test_main.c
@@ -20,7 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#if defined (HAVE_SYS_TYPES) && (HAVE_SYS_TYPES == 1)
+#if defined (HAVE_SYS_TYPES_H) && (HAVE_SYS_TYPES_H == 1)
 #include <sys/types.h>
 #endif
 #include <string.h>

--- a/tests/win32_ordinal_test.c
+++ b/tests/win32_ordinal_test.c
@@ -31,7 +31,9 @@
 
 #include <string.h>
 #include <fcntl.h>
-#include <dirent.h>
+#ifdef HAVE_DIRECT_H
+#include <direct.h>
+#endif
 #include <sys/types.h>
 
 #include "utils.h"


### PR DESCRIPTION
* src/test_main.c: Fix typo in HAVE_SYS_TYPES_H definition
* tests/win32_ordinal_test.c: Use correct "direct.h" header instead of "dirent.h"

Related: https://github.com/erikd/libsndfile/issues/154, https://github.com/erikd/libsndfile/pull/234