### PR TITLE
Fix win32_ordinal_test

### DIFF
--- a/tests/win32_ordinal_test.c
+++ b/tests/win32_ordinal_test.c
@@ -91,7 +91,7 @@ win32_ordinal_test (void)
 	int k, ordinal, errors = 0 ;
 
 	for (k = 0 ; locations [k] != NULL ; k++)
-	{	snprintf (buffer, sizeof (buffer), "%s/libsndfile-1.def", locations [k]) ;
+	{	snprintf (buffer, sizeof (buffer), "%s/libsndfile.def", locations [k]) ;
 		if ((file = fopen (buffer, "r")) != NULL)
 			break ;
 		} ;


### PR DESCRIPTION
The name of Win32 definition file was changed from `libsndfile-1.def` to `libsndfile.def`, test source is modified to reflect these changes.