### PR TITLE
Fix sndfile-regtest compilation with MSVC

### DIFF
--- a/regtest/database.c
+++ b/regtest/database.c
@@ -27,6 +27,9 @@
 #endif
 #include <string.h>
 #include <fcntl.h>
+#ifdef HAVE_DIRECT_H
+#include <direct.h>
+#endif
 #include <sys/stat.h>
 
 #include <sndfile.h>


### PR DESCRIPTION
`getcwd` function requires `direct.h` header.