### PR TITLE
Fix CPU detection regression

### DIFF
--- a/src/sfconfig.h
+++ b/src/sfconfig.h
@@ -115,12 +115,13 @@
 
 #if (defined (__i486__) || defined (__i586__) || defined (__i686__) || defined (__x86_64__))
 #define CPU_IS_X86 1
-#define CPU_IS_X86_64 0
-#elif defined __x86_64__
-#define CPU_IS_X86 0
-#define CPU_IS_X86_64 1
 #else
 #define CPU_IS_X86 0
+#endif
+
+#if defined (__x86_64__)
+#define CPU_IS_X86_64 1
+#else
 #define CPU_IS_X86_64 0
 #endif
 


### PR DESCRIPTION
On Intel cpus, CPU_IS_X86_64 was always defined to 0.

* regression introduced in 8321896954d6e53e9b2bdf025ce8e7202c0fd7d3