### PR TITLE
Fix compilation with devkitpro and vitasdk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,13 @@ AS_CASE([$host_os],
 			])
 	])
 
+AS_CASE([$host_vendor],
+	[vita], [
+		TYPEOF_SF_COUNT_T="int64_t"
+		SF_COUNT_MAX="0x7FFFFFFFFFFFFFFFLL"
+		SIZEOF_SF_COUNT_T=8
+	])
+
 AS_IF([test "x$SIZEOF_SF_COUNT_T" = "x4"], [
 		SF_COUNT_MAX="0x7FFFFFFF"
 	])

--- a/src/GSM610/gsm610_priv.h
+++ b/src/GSM610/gsm610_priv.h
@@ -7,6 +7,8 @@
 #ifndef	PRIVATE_H
 #define	PRIVATE_H
 
+#include <stdint.h>
+
 /* Added by Erik de Castro Lopo */
 #define	USE_FLOAT_MUL
 #define	FAST
@@ -16,14 +18,6 @@
 #error "This code is not designed to be compiled with a C++ compiler."
 #endif
 /* Added by Erik de Castro Lopo */
-
-
-
-typedef short				int16_t ;		/* 16 bit signed int	*/
-typedef int					int32_t ;	/* 32 bit signed int	*/
-
-typedef unsigned short		uint16_t ;		/* unsigned int16_t	*/
-typedef unsigned int		uint32_t ;	/* unsigned int32_t	*/
 
 struct gsm_state
 {	int16_t			dp0 [280] ;

--- a/src/wavlike.h
+++ b/src/wavlike.h
@@ -340,10 +340,10 @@ void	wavlike_write_guid (SF_PRIVATE *psf, const EXT_SUBFORMAT * subformat) ;
 void	wavlike_analyze (SF_PRIVATE *psf) ;
 int		wavlike_gen_channel_mask (const int *chan_map, int channels) ;
 
-int		wavlike_read_bext_chunk (SF_PRIVATE *psf, unsigned int chunksize) ;
+int		wavlike_read_bext_chunk (SF_PRIVATE *psf, uint32_t chunksize) ;
 int		wavlike_write_bext_chunk (SF_PRIVATE *psf) ;
 
-int		wavlike_read_cart_chunk (SF_PRIVATE *psf, unsigned int chunksize) ;
+int		wavlike_read_cart_chunk (SF_PRIVATE *psf, uint32_t chunksize) ;
 int		wavlike_write_cart_chunk (SF_PRIVATE *psf) ;
 
 int		wavlike_subchunk_parse	(SF_PRIVATE *psf, int chunk, uint32_t length) ;


### PR DESCRIPTION
devkitPro is a toolchain that offers compilers for Nintendo 3DS (ARM) and Wii (big endian PPC) homebrew developemtn. And vitasdk for Playstation Portable and PSVita homebrew. So is a bit exotic.

The only problems are that the compilers don't agree on the types for uint32_t & co.
E.g. wavlike_read_bext_chunk uses "uint32_t" in the c-file but "unsigned int" in the header.

And in gsm610_priv.h it fails because of redefinition. I saw that you use "stdint.h" everywhere so including it here is fine I guess?

And on the vita the configure script is unable to determine the size of SF_COUNT_T

Fix #310 