### PR TITLE
Custom scale

### DIFF
--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -22,6 +22,7 @@
 #include	<string.h>
 #include	<ctype.h>
 #include	<assert.h>
+#include	<math.h>
 
 #include	"sndfile.h"
 #include	"sfendian.h"
@@ -969,8 +970,20 @@ sf_command	(SNDFILE *sndfile, int command, void *data, int datasize)
 
 			psf->float_int_mult = (datasize != 0) ? SF_TRUE : SF_FALSE ;
 			if (psf->float_int_mult && psf->float_max < 0.0)
-				/* Scale to prevent wrap-around distortion. */
-				psf->float_max = (32768.0 / 32767.0) * psf_calc_signal_max (psf, SF_FALSE) ;
+			{
+				if (NULL == data)
+				{
+					/* Scale to prevent wrap-around distortion. */
+					psf->float_max = (32768.0 / 32767.0) * psf_calc_signal_max (psf, SF_FALSE) ;
+				}
+				else
+				{
+					if (isfinite(*(float *)data) && *(float *)data > 0.0)
+						psf->float_max = *(float *)data;
+					else
+						return (sf_errno = SFE_BAD_COMMAND_PARAM) ;
+				}
+			}
 			return old_value ;
 
 		case SFC_SET_SCALE_INT_FLOAT_WRITE :


### PR DESCRIPTION
During import, when converting from float to integer values, the caller can now specify a custom floating point value.
Old behavior is kept, and existing application won't break.

I figured out how to use that `SFE_BAD_COMMAND_PARAM` in case of wrong parameter, maybe that needs fixing...