### PR TITLE
Clipping of negative values

### DIFF
--- a/src/double64.c
+++ b/src/double64.c
@@ -519,7 +519,7 @@ d2i_clip_array (const double *src, int count, int *dest, double scale)
 
 		if (CPU_CLIPS_POSITIVE == 0 && tmp > (1.0 * INT_MAX))
 			dest [count] = INT_MAX ;
-		else if (CPU_CLIPS_NEGATIVE == 0 && tmp < (-1.0 * INT_MAX))
+		else if (CPU_CLIPS_NEGATIVE == 0 && tmp < (1.0 * INT_MIN))
 			dest [count] = INT_MIN ;
 		else
 			dest [count] = lrint (tmp) ;

--- a/src/float32.c
+++ b/src/float32.c
@@ -470,7 +470,7 @@ f2i_clip_array (const float *src, int count, int *dest, float scale)
 
 		if (CPU_CLIPS_POSITIVE == 0 && tmp > (1.0 * INT_MAX))
 			dest [count] = INT_MAX ;
-		else if (CPU_CLIPS_NEGATIVE == 0 && tmp < (-1.0 * INT_MAX))
+		else if (CPU_CLIPS_NEGATIVE == 0 && tmp < (1.0 * INT_MIN))
 			dest [count] = INT_MIN ;
 		else
 			dest [count] = lrintf (tmp) ;


### PR DESCRIPTION
This PR fixes a couple of misplaced INT_MAX in floating point to integer conversion.
Or, at least, they seem so.