### PR TITLE
Seeking with fileoffset fixes

### DIFF
--- a/src/file_io.c
+++ b/src/file_io.c
@@ -264,11 +264,10 @@ psf_fseek (SF_PRIVATE *psf, sf_count_t offset, int whence)
 
 	/* When decoding from pipes sometimes see seeks to the pipeoffset, which appears to mean do nothing. */
 	if (psf->is_pipe)
-	{
-		if (whence != SEEK_SET || offset != psf->pipeoffset)
+	{	if (whence != SEEK_SET || offset != psf->pipeoffset)
 			psf_log_printf (psf, "psf_fseek : pipe seek to value other than pipeoffset\n") ;
 		return offset ;
-	}
+		}
 
 	switch (whence)
 	{	case SEEK_SET :

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -262,6 +262,14 @@ psf_fseek (SF_PRIVATE *psf, sf_count_t offset, int whence)
 	if (psf->virtual_io)
 		return psf->vio.seek (offset, whence, psf->vio_user_data) ;
 
+	/* When decoding from pipes sometimes see seeks to the pipeoffset, which appears to mean do nothing. */
+	if (psf->is_pipe)
+	{
+		if (whence != SEEK_SET || offset != psf->pipeoffset)
+			psf_log_printf (psf, "psf_fseek : pipe seek to value other than pipeoffset\n") ;
+		return offset ;
+	}
+
 	switch (whence)
 	{	case SEEK_SET :
 				offset += psf->fileoffset ;

--- a/src/test_file_io.c
+++ b/src/test_file_io.c
@@ -48,6 +48,7 @@ static void test_write_or_die	(SF_PRIVATE *psf, void *data, sf_count_t bytes, sf
 static void test_read_or_die	(SF_PRIVATE *psf, void *data, sf_count_t bytes, sf_count_t items, sf_count_t new_position, int linenum) ;
 static void test_equal_or_die	(int *array1, int *array2, int len, int linenum) ;
 static void test_seek_or_die (SF_PRIVATE *psf, sf_count_t offset, int whence, sf_count_t new_position, int linenum) ;
+static void test_tell_or_die	(SF_PRIVATE *psf, sf_count_t expected_position, int linenum) ;
 
 
 
@@ -326,6 +327,42 @@ file_truncate_test (const char *filename)
 	puts ("ok") ;
 } /* file_truncate_test */
 
+static void
+file_seek_with_offset_test (const char *filename)
+{	SF_PRIVATE sf_data, *psf ;
+	sf_count_t real_end ;
+	const size_t fileoffset = 64 ;
+
+	print_test_name ("Testing seek with offset") ;
+
+	/* Open the file created by the previous test for reading. */
+	memset (&sf_data, 0, sizeof (sf_data)) ;
+	psf = &sf_data ;
+	psf->file.mode = SFM_READ ;
+	snprintf (psf->file.path.c, sizeof (psf->file.path.c), "%s", filename) ;
+	test_open_or_die (psf, __LINE__) ;
+
+	/* Gather basic info before setting offset. */
+	real_end = psf_fseek (psf, 0, SEEK_END) ;
+	test_tell_or_die (psf, real_end, __LINE__) ;
+
+	/* Set the fileoffset (usually in a real system this is due to an id3 tag). */
+	psf->fileoffset = fileoffset ;
+
+	/* Check tell respects offset. */
+	test_tell_or_die (psf, real_end - fileoffset, __LINE__) ;
+
+	/* Check seeking works as expected. */
+	test_seek_or_die (psf, 0, SEEK_SET, 0, __LINE__) ;
+	test_seek_or_die (psf, 0, SEEK_CUR, 0, __LINE__) ;
+	test_seek_or_die (psf, 0, SEEK_CUR, 0, __LINE__) ;
+	test_seek_or_die (psf, 0, SEEK_END, real_end - fileoffset, __LINE__) ;
+
+	test_close_or_die (psf, __LINE__) ;
+
+	puts ("ok") ;
+} /* file_seek_with_offset_test */
+
 /*==============================================================================
 ** Testing helper functions.
 */
@@ -405,6 +442,20 @@ test_seek_or_die (SF_PRIVATE *psf, sf_count_t offset, int whence, sf_count_t new
 } /* test_seek_or_die */
 
 static void
+test_tell_or_die	(SF_PRIVATE *psf, sf_count_t expected_position, int linenum)
+{
+	sf_count_t retval ;
+
+	retval = psf_ftell (psf) ;
+
+	if (retval != expected_position)
+	{	printf ("\n\nLine %d: psf_ftell() failed. Position reported as %" PRId64 " (should be %" PRId64 ").\n\n",
+			linenum, retval, expected_position) ;
+		exit (1) ;
+		} ;
+}
+
+static void
 test_equal_or_die	(int *array1, int *array2, int len, int linenum)
 {	int k ;
 
@@ -433,6 +484,7 @@ test_file_io (void)
 
 	file_open_test	(filename) ;
 	file_read_write_test	(filename) ;
+	file_seek_with_offset_test (filename) ;
 	file_truncate_test (filename) ;
 
 	unlink (filename) ;


### PR DESCRIPTION
I believe this tests and fixes the strange behaviour seen in #320.

Whether the fileoffset had been accounted for was unclear in the seek function and didn't seem to be fully correct. Hopefully this makes it clearer and avoids some of the edge cases.

Not sure whether I have handled pipeoffset correctly although I believe I have made explicit the existing behaviour.