### PR TITLE
sfe_copy_data_fp: check value of "max" variable for being normal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,9 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-convert ${sndfile_convert_SOURCES})
 	target_link_libraries(sndfile-convert PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+	endif ()
 
 # sndfile-cmp
 
@@ -514,6 +517,9 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-metadata-set ${sndfile_metadata_set_SOURCES})
 	target_link_libraries(sndfile-metadata-set PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-metadata-set PRIVATE ${M_LIBRARY})
+	endif ()
 
 # sndfile-metadata-get
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,7 +477,7 @@ if (BUILD_PROGRAMS)
 	add_executable (sndfile-play ${sndfile_play_SOURCES})
 	target_link_libraries(sndfile-play PUBLIC ${SNDFILE_TARGET})
 	if (LIBM_REQUIRED)
-		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+		target_link_libraries(sndfile-play PRIVATE ${M_LIBRARY})
 	endif ()
 	if (WIN32)
 		target_link_libraries(sndfile-play PRIVATE Winmm.lib)
@@ -512,7 +512,7 @@ if (BUILD_PROGRAMS)
 	add_executable (sndfile-cmp ${sndfile_cmp_SOURCES})
 	target_link_libraries(sndfile-cmp PUBLIC ${SNDFILE_TARGET})
 	if (LIBM_REQUIRED)
-		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+		target_link_libraries(sndfile-cmp PRIVATE ${M_LIBRARY})
 	endif ()
 
 # sndfile-metadata-set
@@ -536,7 +536,7 @@ if (BUILD_PROGRAMS)
 	add_executable (sndfile-metadata-get ${sndfile_metadata_get_SOURCES})
 	target_link_libraries(sndfile-metadata-get PUBLIC ${SNDFILE_TARGET})
 	if (LIBM_REQUIRED)
-		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+		target_link_libraries(sndfile-metadata-get PRIVATE ${M_LIBRARY})
 	endif ()
 
 # sndfile-interleave
@@ -548,7 +548,7 @@ if (BUILD_PROGRAMS)
 	add_executable (sndfile-interleave ${sndfile_interleave_SOURCES})
 	target_link_libraries(sndfile-interleave PUBLIC ${SNDFILE_TARGET})
 	if (LIBM_REQUIRED)
-		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+		target_link_libraries(sndfile-interleave PRIVATE ${M_LIBRARY})
 	endif ()
 
 # sndfile-deinterleave
@@ -560,7 +560,7 @@ if (BUILD_PROGRAMS)
 	add_executable (sndfile-deinterleave ${sndfile_deinterleave_SOURCES})
 	target_link_libraries(sndfile-deinterleave PUBLIC ${SNDFILE_TARGET})
 	if (LIBM_REQUIRED)
-		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+		target_link_libraries(sndfile-deinterleave PRIVATE ${M_LIBRARY})
 	endif ()
 
 # sndfile-concat
@@ -572,7 +572,7 @@ if (BUILD_PROGRAMS)
 	add_executable (sndfile-concat ${sndfile_concat_SOURCES})
 	target_link_libraries(sndfile-concat PUBLIC ${SNDFILE_TARGET})
 	if (LIBM_REQUIRED)
-		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+		target_link_libraries(sndfile-concat PRIVATE ${M_LIBRARY})
 	endif ()
 
 # sndfile-salvage
@@ -584,7 +584,7 @@ if (BUILD_PROGRAMS)
 	add_executable (sndfile-salvage ${sndfile_salvage_SOURCES})
 	target_link_libraries(sndfile-salvage PUBLIC ${SNDFILE_TARGET})
 	if (LIBM_REQUIRED)
-		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+		target_link_libraries(sndfile-salvage PRIVATE ${M_LIBRARY})
 	endif ()
 
 	set (SNDFILE_PROGRAM_TARGETS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,7 +458,7 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-info ${sndfile_info_SOURCES})
 	target_link_libraries(sndfile-info PUBLIC ${SNDFILE_TARGET})
-	if (BUILD_SHARED_LIBS AND LIBM_REQUIRED)
+	if (LIBM_REQUIRED)
 		target_link_libraries(sndfile-info PRIVATE ${M_LIBRARY})
 	endif ()
 
@@ -476,6 +476,9 @@ if (BUILD_PROGRAMS)
 
 	add_executable (sndfile-play ${sndfile_play_SOURCES})
 	target_link_libraries(sndfile-play PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+	endif ()
 	if (WIN32)
 		target_link_libraries(sndfile-play PRIVATE Winmm.lib)
 	# Maybe ALSA & Sndio are present in BeOS. They are not required
@@ -508,6 +511,9 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-cmp ${sndfile_cmp_SOURCES})
 	target_link_libraries(sndfile-cmp PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+	endif ()
 
 # sndfile-metadata-set
 
@@ -529,6 +535,9 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-metadata-get ${sndfile_metadata_get_SOURCES})
 	target_link_libraries(sndfile-metadata-get PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+	endif ()
 
 # sndfile-interleave
 
@@ -538,6 +547,9 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-interleave ${sndfile_interleave_SOURCES})
 	target_link_libraries(sndfile-interleave PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+	endif ()
 
 # sndfile-deinterleave
 
@@ -547,6 +559,9 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-deinterleave ${sndfile_deinterleave_SOURCES})
 	target_link_libraries(sndfile-deinterleave PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+	endif ()
 
 # sndfile-concat
 
@@ -556,6 +571,9 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-concat ${sndfile_concat_SOURCES})
 	target_link_libraries(sndfile-concat PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+	endif ()
 
 # sndfile-salvage
 
@@ -565,6 +583,9 @@ if (BUILD_PROGRAMS)
 		programs/common.h)
 	add_executable (sndfile-salvage ${sndfile_salvage_SOURCES})
 	target_link_libraries(sndfile-salvage PUBLIC ${SNDFILE_TARGET})
+	if (LIBM_REQUIRED)
+		target_link_libraries(sndfile-convert PRIVATE ${M_LIBRARY})
+	endif ()
 
 	set (SNDFILE_PROGRAM_TARGETS
 		sndfile-info

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,7 +67,7 @@ src_libsndfile_la_SOURCES = src/sndfile.c src/aiff.c src/au.c src/avr.c src/caf.
 	src/sf_unistd.h src/ogg.h src/chanmap.h
 nodist_src_libsndfile_la_SOURCES = $(nodist_include_HEADERS)
 src_libsndfile_la_LIBADD = src/GSM610/libgsm.la src/G72x/libg72x.la src/ALAC/libalac.la \
-	src/libcommon.la $(EXTERNAL_XIPH_LIBS) -lm
+	src/libcommon.la $(EXTERNAL_XIPH_LIBS) $(LIBM)
 EXTRA_src_libsndfile_la_DEPENDENCIES = $(SYMBOL_FILES)
 
 noinst_LTLIBRARIES = src/libcommon.la
@@ -421,13 +421,13 @@ programs_sndfile_play_SOURCES = programs/sndfile-play.c programs/common.c progra
 programs_sndfile_play_LDADD = src/libsndfile.la $(OS_SPECIFIC_LINKS) $(ALSA_LIBS) $(SNDIO_LIBS)
 
 programs_sndfile_convert_SOURCES = programs/sndfile-convert.c programs/common.c programs/common.h
-programs_sndfile_convert_LDADD = src/libsndfile.la
+programs_sndfile_convert_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_cmp_SOURCES = programs/sndfile-cmp.c programs/common.c programs/common.h
 programs_sndfile_cmp_LDADD = src/libsndfile.la
 
 programs_sndfile_metadata_set_SOURCES = programs/sndfile-metadata-set.c programs/common.c programs/common.h
-programs_sndfile_metadata_set_LDADD = src/libsndfile.la
+programs_sndfile_metadata_set_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_metadata_get_SOURCES = programs/sndfile-metadata-get.c programs/common.c programs/common.h
 programs_sndfile_metadata_get_LDADD = src/libsndfile.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -415,34 +415,34 @@ endif
 EXTRA_DIST += programs/sndfile-play-beos.cpp programs/test-sndfile-metadata-set.py
 
 programs_sndfile_info_SOURCES = programs/sndfile-info.c programs/common.c programs/common.h
-programs_sndfile_info_LDADD = src/libsndfile.la
+programs_sndfile_info_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_play_SOURCES = programs/sndfile-play.c programs/common.c programs/common.h
-programs_sndfile_play_LDADD = src/libsndfile.la $(OS_SPECIFIC_LINKS) $(ALSA_LIBS) $(SNDIO_LIBS)
+programs_sndfile_play_LDADD = src/libsndfile.la $(OS_SPECIFIC_LINKS) $(ALSA_LIBS) $(SNDIO_LIBS) $(LIBM)
 
 programs_sndfile_convert_SOURCES = programs/sndfile-convert.c programs/common.c programs/common.h
 programs_sndfile_convert_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_cmp_SOURCES = programs/sndfile-cmp.c programs/common.c programs/common.h
-programs_sndfile_cmp_LDADD = src/libsndfile.la
+programs_sndfile_cmp_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_metadata_set_SOURCES = programs/sndfile-metadata-set.c programs/common.c programs/common.h
 programs_sndfile_metadata_set_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_metadata_get_SOURCES = programs/sndfile-metadata-get.c programs/common.c programs/common.h
-programs_sndfile_metadata_get_LDADD = src/libsndfile.la
+programs_sndfile_metadata_get_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_interleave_SOURCES = programs/sndfile-interleave.c programs/common.c programs/common.h
-programs_sndfile_interleave_LDADD = src/libsndfile.la
+programs_sndfile_interleave_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_deinterleave_SOURCES = programs/sndfile-deinterleave.c programs/common.c programs/common.h
-programs_sndfile_deinterleave_LDADD = src/libsndfile.la
+programs_sndfile_deinterleave_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_concat_SOURCES = programs/sndfile-concat.c programs/common.c programs/common.h
-programs_sndfile_concat_LDADD = src/libsndfile.la
+programs_sndfile_concat_LDADD = src/libsndfile.la $(LIBM)
 
 programs_sndfile_salvage_SOURCES = programs/sndfile-salvage.c programs/common.c programs/common.h
-programs_sndfile_salvage_LDADD = src/libsndfile.la
+programs_sndfile_salvage_LDADD = src/libsndfile.la $(LIBM)
 
 ############
 # regtest/ #

--- a/configure.ac
+++ b/configure.ac
@@ -289,6 +289,9 @@ AC_CHECK_FUNCS([mmap getpagesize])
 AC_CHECK_FUNCS([setlocale])
 AC_CHECK_FUNCS([pipe waitpid])
 
+AC_CHECK_LIBM
+AC_SUBST(LIBM)
+
 AC_SEARCH_LIBS([floor], [m], [], [
 		AC_MSG_ERROR([unable to find the floor() function!])
 	])

--- a/programs/common.c
+++ b/programs/common.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdint.h>
+#include <math.h>
 
 #include <sndfile.h>
 
@@ -45,7 +46,7 @@
 
 #define	MIN(x, y)	((x) < (y) ? (x) : (y))
 
-void
+int
 sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize)
 {	static double	data [BUFFER_LEN], max ;
 	sf_count_t		frames, readcount, k ;
@@ -54,6 +55,8 @@ sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize
 	readcount = frames ;
 
 	sf_command (infile, SFC_CALC_SIGNAL_MAX, &max, sizeof (max)) ;
+	if (!isnormal (max)) /* neither zero, subnormal, infinite, nor NaN */
+		return 1 ;
 
 	if (!normalize && max < 1.0)
 	{	while (readcount > 0)
@@ -67,12 +70,16 @@ sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize
 		while (readcount > 0)
 		{	readcount = sf_readf_double (infile, data, frames) ;
 			for (k = 0 ; k < readcount * channels ; k++)
-				data [k] /= max ;
+			{	data [k] /= max ;
+
+				if (!isfinite (data [k])) /* infinite or NaN */
+					return 1;
+				}
 			sf_writef_double (outfile, data, readcount) ;
 			} ;
 		} ;
 
-	return ;
+	return 0 ;
 } /* sfe_copy_data_fp */
 
 void
@@ -252,7 +259,12 @@ sfe_apply_metadata_changes (const char * filenames [2], const METADATA_INFO * in
 
 		/* If the input file is not the same as the output file, copy the data. */
 		if ((infileminor == SF_FORMAT_DOUBLE) || (infileminor == SF_FORMAT_FLOAT))
-			sfe_copy_data_fp (outfile, infile, sfinfo.channels, SF_FALSE) ;
+		{	if (sfe_copy_data_fp (outfile, infile, sfinfo.channels, SF_FALSE) != 0)
+			{	printf ("Error : Not able to decode input file '%s'\n", filenames [0]) ;
+				error_code = 1 ;
+				goto cleanup_exit ;
+				} ;
+			}
 		else
 			sfe_copy_data_int (outfile, infile, sfinfo.channels) ;
 		} ;

--- a/programs/common.h
+++ b/programs/common.h
@@ -62,7 +62,7 @@ typedef SF_BROADCAST_INFO_VAR (2048) SF_BROADCAST_INFO_2K ;
 
 void sfe_apply_metadata_changes (const char * filenames [2], const METADATA_INFO * info) ;
 
-void sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize) ;
+int sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize) ;
 
 void sfe_copy_data_int (SNDFILE *outfile, SNDFILE *infile, int channels) ;
 

--- a/programs/sndfile-convert.c
+++ b/programs/sndfile-convert.c
@@ -335,7 +335,11 @@ main (int argc, char * argv [])
 			|| (outfileminor == SF_FORMAT_DOUBLE) || (outfileminor == SF_FORMAT_FLOAT)
 			|| (infileminor == SF_FORMAT_DOUBLE) || (infileminor == SF_FORMAT_FLOAT)
 			|| (infileminor == SF_FORMAT_VORBIS) || (outfileminor == SF_FORMAT_VORBIS))
-		sfe_copy_data_fp (outfile, infile, sfinfo.channels, normalize) ;
+	{	if (sfe_copy_data_fp (outfile, infile, sfinfo.channels, normalize) != 0)
+		{	printf ("Error : Not able to decode input file %s.\n", infilename) ;
+			return 1 ;
+			} ;
+		}
 	else
 		sfe_copy_data_int (outfile, infile, sfinfo.channels) ;
 


### PR DESCRIPTION
and check elements of the data[] array for being finite.

Both checks use functions provided by the <math.h> header as declared
by the C99 standard.

Fixes #317
CVE-2017-14245
CVE-2017-14246