### PR TITLE
double64_init: force psf->sf.channels in a reasonable range

### DIFF
--- a/src/double64.c
+++ b/src/double64.c
@@ -91,7 +91,7 @@ int
 double64_init	(SF_PRIVATE *psf)
 {	static int double64_caps ;
 
-	if (psf->sf.channels < 1)
+	if (psf->sf.channels < 1 || psf->sf.channels > SF_MAX_CHANNELS)
 	{	psf_log_printf (psf, "double64_init : internal error : channels = %d\n", psf->sf.channels) ;
 		return SFE_INTERNAL ;
 		} ;


### PR DESCRIPTION
This prevents division by zero later in the code.

While the trivial case to catch this (i.e. sf.channels < 1) has already
been covered, a crafted file may report a number of channels that is
so high (i.e. > INT_MAX/sizeof(double)) that it "somehow" gets
miscalculated to zero (if this makes sense) in the determination of the
blockwidth. Since we only support a limited number of channels anyway,
make sure to check here as well.

Fixes #318
CVE-2017-14634