### PR TITLE
Remove unused internal header includes from examples.

### DIFF
--- a/examples/generate.c
+++ b/examples/generate.c
@@ -30,8 +30,6 @@
 ** ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "sfconfig.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/sndfile-loopify.c
+++ b/examples/sndfile-loopify.c
@@ -44,8 +44,6 @@
 
 #include <sndfile.h>
 
-#include "common.h"
-
 #define BUFFER_LEN		(1 << 14)
 
 


### PR DESCRIPTION
These headers aren't used by the examples (as far as I could tell). Removing these includes would help make them look more like real user programs that may not have access to these files and make it faster and require less extra files to compile after copy-pasting somewhere else.