### PR TITLE
src/sfconfig.h: Fix CPU architecture detection under Windows

### DIFF
--- a/src/sfconfig.h
+++ b/src/sfconfig.h
@@ -113,10 +113,10 @@
 #define HAVE_X86INTRIN_H 0
 #endif
 
-#if defined __x86_64__
+#if (defined __x86_64__) || (defined _M_X64)
 #define CPU_IS_X86_64	1	/* Define both for x86_64 */
 #define CPU_IS_X86		1
-#elif defined (__i486__) || defined (__i586__) || defined (__i686__)
+#elif defined (__i486__) || defined (__i586__) || defined (__i686__) || defined (_M_IX86)
 #define CPU_IS_X86 		1
 #define CPU_IS_X86_64 	0
 #else


### PR DESCRIPTION
`__x86_64__`, `__i486__`, `__i586__`, `__i686__` are not defined under MSVC, so `CPU_IS_X86` and `CPU_IS_X86_64` are always `0`:

![default](https://user-images.githubusercontent.com/11195016/31848942-37427716-b654-11e7-969f-396eff79bdd2.PNG)

[MSDN: Predefined Macros](https://msdn.microsoft.com/en-US/library/b0084kay(v=vs.140).aspx)
