### PR TITLE
sndfile.c: Return the length of log output

### DIFF
--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -1031,7 +1031,7 @@ sf_command	(SNDFILE *sndfile, int command, void *data, int datasize)
 			if (data == NULL)
 				return SFE_BAD_COMMAND_PARAM ;
 			snprintf (data, datasize, "%s", psf->parselog.buf) ;
-			break ;
+			return strlen (data) ;
 
 		case SFC_CALC_SIGNAL_MAX :
 			if (data == NULL || datasize != sizeof (double))


### PR DESCRIPTION
There were two handers for SFC_GET_LOG_INFO and one incorrectly was
not returning the length of log string.

Closes: https://github.com/erikd/libsndfile/issues/345