### PR TITLE
src/sndfile.c: Set SFC_GET_LIB_VERSION return result to 0 on error

### DIFF
--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -888,7 +888,7 @@ sf_command	(SNDFILE *sndfile, int command, void *data, int datasize)
 			if (data == NULL)
 			{	if (psf)
 					psf->error = SFE_BAD_COMMAND_PARAM ;
-				return SFE_BAD_COMMAND_PARAM ;
+				return 0 ;
 				} ;
 			snprintf (data, datasize, "%s", sf_version_string ()) ;
 			return strlen (data) ;


### PR DESCRIPTION
If `data == NULL` string is not copied but command returns `SFE_BAD_COMMAND_PARAM (31)`. It can be misunsderstood as string length.

Related to issue #345.