### PR TITLE
--enable-octave means enable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ AC_ARG_ENABLE([external-libs],
 	[AS_HELP_STRING([--disable-external-libs], [disable use of FLAC, Ogg and Vorbis [[default=no]]])])
 
 AC_ARG_ENABLE(octave,
-	[AS_HELP_STRING([--enable-octave], [disable building of GNU Octave module])])
+	[AS_HELP_STRING([--enable-octave], [enable building of GNU Octave module])])
 
 AC_ARG_ENABLE([full-suite],
 	[AS_HELP_STRING([--disable-full-suite], [disable building and installing programs, documentation, only build library [[default=no]]])])


### PR DESCRIPTION
This fixes a typo in ./configure --help  