### PR TITLE
drop MacOSX from sndfile-play

### DIFF
--- a/programs/sndfile-play.c
+++ b/programs/sndfile-play.c
@@ -61,10 +61,6 @@
 	#include 	<sys/ioctl.h>
 	#include 	<sys/soundcard.h>
 
-#elif (defined (__MACH__) && defined (__APPLE__))
-	#include <AvailabilityMacros.h>
-	#include <Availability.h>
-
 #elif HAVE_SNDIO_H
 	#include <sndio.h>
 
@@ -852,16 +848,12 @@ main (int argc, char *argv [])
 	solaris_play (argc, argv) ;
 #elif (OS_IS_WIN32 == 1)
 	win32_play (argc, argv) ;
-#elif (defined (__MACH__) && defined (__APPLE__))
-	printf ("OS X 10.8 and later have a new Audio API.\n") ;
-	printf ("Someone needs to write code to use that API.\n") ;
-	return 1 ;
 #elif defined (__BEOS__)
 	printf ("This program cannot be compiled on BeOS.\n") ;
 	printf ("Instead, compile the file sfplay_beos.cpp.\n") ;
 	return 1 ;
 #else
-	puts ("*** Playing sound not yet supported on this platform.") ;
+	puts ("*** Playing sound not supported on this platform.") ;
 	puts ("*** Please feel free to submit a patch.") ;
 	return 1 ;
 #endif


### PR DESCRIPTION
We don't play on MacOSX >= 10.8 (the code for the new API is not written),
and support for MacOSX older than that was removed some time ago.
So drop the last remnants; we just don't play on MacOSX.