### PR TITLE
src/wav.c: Fix skipping of erroneous subchunks

### DIFF
--- a/src/wavlike.c
+++ b/src/wavlike.c
@@ -963,7 +963,7 @@ wavlike_subchunk_parse (SF_PRIVATE *psf, int chunk, uint32_t chunk_length)
 					*/
 					psf_log_printf (psf, "    *** Found weird-ass zero marker. Jumping to end of chunk.\n") ;
 					if (bytesread < chunk_length)
-						bytesread += psf_binheader_readf (psf, "j", chunk_length - bytesread + 4) ;
+						bytesread += psf_binheader_readf (psf, "j", chunk_length - bytesread) ;
 					psf_log_printf (psf, "    *** Offset is now : 0x%X\n", psf_fseek (psf, 0, SEEK_CUR)) ;
 					return 0 ;
 


### PR DESCRIPTION
Closes: https://github.com/erikd/libsndfile/issues/370