### PR TITLE
Avoid seeks in ogg_open (), Introduce ogg_read_first_page ()

### DIFF
--- a/src/ogg.c
+++ b/src/ogg.c
@@ -46,6 +46,87 @@ static int	ogg_close (SF_PRIVATE *psf) ;
 static int	ogg_stream_classify (SF_PRIVATE *psf, OGG_PRIVATE * odata) ;
 static int	ogg_page_classify (SF_PRIVATE * psf, const ogg_page * og) ;
 
+int ogg_read_first_page (SF_PRIVATE *psf, OGG_PRIVATE *odata)
+{	char *buffer ;
+	int	bytes ;
+
+	/*
+	** The ogg standard requires that the first pages of a physical ogg
+	** bitstream be only the first pages of each logical bitstream. These
+	** pages MUST have the Beginning-Of-Stream bit set, and must contain
+	** only the stream's relevant header. Currently we only load the first
+	** page and check that it contains a codec we support as supporting
+	** multiplexed streams (video+audio(en)+audio(fs)+subtitles, etc) is
+	** beyond the scope of this library.
+	*/
+
+	/* Weird stuff happens if these aren't called. */
+	ogg_stream_reset (&odata->ostream) ;
+	ogg_sync_reset (&odata->osync) ;
+
+	/* Expose the buffer */
+	buffer = ogg_sync_buffer (&odata->osync, 4096L) ;
+
+	/*
+	** Grab some data. Beginning-of-stream Ogg pages are guarenteed to be
+	** small. 4096 bytes ought to be enough.
+	*/
+
+	/* Avoid seeking if the file has just been opened. */
+	if (psf_ftell (psf) == psf->header.indx)
+	{	/* Grab the part of the header that has already been read. */
+		memcpy (buffer, psf->header.ptr, psf->header.indx) ;
+		bytes = psf->header.indx ;
+		bytes += psf_fread (buffer + psf->header.indx, 1, 4096 - psf->header.indx, psf) ;
+		}
+	else
+	{	if (psf_fseek (psf, 0, SEEK_SET) != 0)
+			return SFE_NOT_SEEKABLE ;
+		bytes = psf_fread (buffer, 1, 4096, psf) ;
+		}
+
+	ogg_sync_wrote (&odata->osync, bytes) ;
+
+	/* Get the first page. Check for Beginning-of-stream bit */
+	if (ogg_sync_pageout (&odata->osync, &odata->opage) != 1 ||
+		ogg_page_bos (&odata->opage) == 0)
+	{
+		/* Have we simply run out of data?  If so, we're done. */
+		if (bytes < 4096)
+			return 0 ;
+
+		/*
+		** Error case. Either must not be an Ogg bitstream, or is in the
+		** middle of a bitstream (live capture), or in the middle of a
+		** bitstream and no complete page was in the buffer.
+		*/
+
+		psf_log_printf (psf, "Input does not appear to be the start of an Ogg bitstream.\n") ;
+		return SFE_MALFORMED_FILE ;
+		} ;
+
+	/*
+	**	Get the serial number and set up the rest of decode.
+	**	Serialno first ; use it to set up a logical stream.
+	*/
+	ogg_stream_clear (&odata->ostream) ;
+	ogg_stream_init (&odata->ostream, ogg_page_serialno (&odata->opage)) ;
+
+	if (ogg_stream_pagein (&odata->ostream, &odata->opage) < 0)
+	{	/* Error ; stream version mismatch perhaps. */
+		psf_log_printf (psf, "Error reading first page of Ogg bitstream data\n") ;
+		return SFE_MALFORMED_FILE ;
+		} ;
+
+	if (ogg_stream_packetout (&odata->ostream, &odata->opacket) != 1)
+	{	/* No page? */
+		psf_log_printf (psf, "Error reading initial header page packet.\n") ;
+		return SFE_MALFORMED_FILE ;
+		} ;
+
+	return 0 ;
+}
+
 int
 ogg_open (SF_PRIVATE *psf)
 {	OGG_PRIVATE* odata = calloc (1, sizeof (OGG_PRIVATE)) ;
@@ -62,11 +143,6 @@ ogg_open (SF_PRIVATE *psf)
 		if ((error = ogg_stream_classify (psf, odata)) != 0)
 			return error ;
 
-	/* Reset everything to an initial state. */
-	ogg_sync_clear (&odata->osync) ;
-	ogg_stream_clear (&odata->ostream) ;
-	psf_fseek (psf, pos, SEEK_SET) ;
-
 	if (SF_ENDIAN (psf->sf.format) != 0)
 		return SFE_BAD_ENDIAN ;
 
@@ -75,6 +151,10 @@ ogg_open (SF_PRIVATE *psf)
 			return ogg_vorbis_open (psf) ;
 
 		case SF_FORMAT_OGGFLAC :
+			/* Reset everything to an initial state. */
+			ogg_sync_clear (&odata->osync) ;
+			ogg_stream_clear (&odata->ostream) ;
+			psf_fseek (psf, pos, SEEK_SET) ;
 			free (psf->container_data) ;
 			psf->container_data = NULL ;
 			psf->container_close = NULL ;
@@ -110,66 +190,14 @@ ogg_close (SF_PRIVATE *psf)
 
 static int
 ogg_stream_classify (SF_PRIVATE *psf, OGG_PRIVATE* odata)
-{	char *buffer ;
-	int	bytes, nn ;
+{	int error ;
 
 	/* Call this here so it only gets called once, so no memory is leaked. */
 	ogg_sync_init (&odata->osync) ;
 
-	odata->eos = 0 ;
-
-	/* Weird stuff happens if these aren't called. */
-	ogg_stream_reset (&odata->ostream) ;
-	ogg_sync_reset (&odata->osync) ;
-
-	/*
-	**	Grab some data at the head of the stream.  We want the first page
-	**	(which is guaranteed to be small and only contain the Vorbis
-	**	stream initial header) We need the first page to get the stream
-	**	serialno.
-	*/
-
-	/* Expose the buffer */
-	buffer = ogg_sync_buffer (&odata->osync, 4096L) ;
-
-	/* Grab the part of the header that has already been read. */
-	memcpy (buffer, psf->header.ptr, psf->header.indx) ;
-	bytes = psf->header.indx ;
-
-	/* Submit a 4k block to libvorbis' Ogg layer */
-	bytes += psf_fread (buffer + psf->header.indx, 1, 4096 - psf->header.indx, psf) ;
-	ogg_sync_wrote (&odata->osync, bytes) ;
-
-	/* Get the first page. */
-	if ((nn = ogg_sync_pageout (&odata->osync, &odata->opage)) != 1)
-	{
-		/* Have we simply run out of data?  If so, we're done. */
-		if (bytes < 4096)
-			return 0 ;
-
-		/* Error case.  Must not be Vorbis data */
-		psf_log_printf (psf, "Input does not appear to be an Ogg bitstream.\n") ;
-		return SFE_MALFORMED_FILE ;
-		} ;
-
-	/*
-	**	Get the serial number and set up the rest of decode.
-	**	Serialno first ; use it to set up a logical stream.
-	*/
-	ogg_stream_clear (&odata->ostream) ;
-	ogg_stream_init (&odata->ostream, ogg_page_serialno (&odata->opage)) ;
-
-	if (ogg_stream_pagein (&odata->ostream, &odata->opage) < 0)
-	{	/* Error ; stream version mismatch perhaps. */
-		psf_log_printf (psf, "Error reading first page of Ogg bitstream data\n") ;
-		return SFE_MALFORMED_FILE ;
-		} ;
-
-	if (ogg_stream_packetout (&odata->ostream, &odata->opacket) != 1)
-	{	/* No page? must not be vorbis. */
-		psf_log_printf (psf, "Error reading initial header packet.\n") ;
-		return SFE_MALFORMED_FILE ;
-		} ;
+	/* Load the first page in the physical bitstream. */
+	if ((error = ogg_read_first_page (psf, odata)) != 0)
+		return error ;
 
 	odata->codec = ogg_page_classify (psf, &odata->opage) ;
 

--- a/src/ogg.h
+++ b/src/ogg.h
@@ -33,7 +33,7 @@ typedef struct
 	ogg_sync_state osync ;
 	/* Take physical pages, weld into a logical stream of packets */
 	ogg_stream_state ostream ;
-	/* One Ogg bitstream page.  Vorbis packets are inside */
+	/* One Ogg bitstream page. Codec packets are inside */
 	ogg_page opage ;
 	/* One raw packet of data for decode */
 	ogg_packet opacket ;
@@ -47,6 +47,6 @@ typedef struct
 								((buf [base + 1] << 8) & 0xff00) | \
 								(buf [base] & 0xff))
 
-
+int	ogg_read_first_page	(SF_PRIVATE *, OGG_PRIVATE *) ;
 
 #endif /* SF_SRC_OGG_H */


### PR DESCRIPTION
This pull request merges duplicate code from from src/ogg.c and src/ogg_vorbis.c into a common function.. The code in question is for reading the first page of an Ogg bitstream. The benefits of such a merge are:

1) Each codec encapsulated by Ogg requires the functionality, so future codecs may use it without duplication as well.

2) Removal of the duplicate code from src/ogg_vorbis.c allows for a more structured way for calling ogg_read_first_page () only as needed, remove the need for re-reading the beginning of the file. In my tests this fixes issue #110 .

This pull request also changes the way ogg_vorbis_open () and ogg_open () interact. Previously ogg_vorbis_open () assumed nothing about the state of the container state, re-initializing all Ogg related structures itself and assuming that the read position was the start of the file. This required ogg_open () to seek to the beginning of the stream before calling ogg_vorbis_open (). After this change ogg_vorbis_open () will assumesthat the container state is already initialized, with the first page loaded.

On backwards seek, src/ogg_vorbis.c still has to re-read the first page, and it will call ogg_read_first_page appropriately.

FLAC in ogg behaviour is unaffected by this change. Speex in ogg (src/ogg_speex.c) has not been modified to take advantage of ogg_read_first_page (), and should be unaffected as well.