### PR TITLE
tests/vrtual_io_test.c: Fix typo

### DIFF
--- a/tests/virtual_io_test.c
+++ b/tests/virtual_io_test.c
@@ -87,7 +87,7 @@ vfread (void *ptr, sf_count_t count, void *user_data)
 {	VIO_DATA *vf = (VIO_DATA *) user_data ;
 
 	/*
-	**	This will brack badly for files over 2Gig in length, but
+	**	This will break badly for files over 2Gig in length, but
 	**	is sufficient for testing.
 	*/
 	if (vf->offset + count > vf->length)


### PR DESCRIPTION
Closes #417
this change is too insignificant to be protected by copyright, this change is in the public domain or licensed under CC0