### PR TITLE
a/ulaw: fix multiple buffer overflows

### DIFF
--- a/src/alaw.c
+++ b/src/alaw.c
@@ -19,6 +19,7 @@
 #include	"sfconfig.h"
 
 #include	<math.h>
+#include	<limits.h>
 
 #include	"sndfile.h"
 #include	"common.h"
@@ -326,7 +327,9 @@ s2alaw_array (const short *ptr, int count, unsigned char *buffer)
 static inline void
 i2alaw_array (const int *ptr, int count, unsigned char *buffer)
 {	while (--count >= 0)
-	{	if (ptr [count] >= 0)
+	{	if (ptr [count] == INT_MIN)
+			buffer [count] = alaw_encode [INT_MAX >> (16 + 4)] ;
+		else if (ptr [count] >= 0)
 			buffer [count] = alaw_encode [ptr [count] >> (16 + 4)] ;
 		else
 			buffer [count] = 0x7F & alaw_encode [- ptr [count] >> (16 + 4)] ;
@@ -346,7 +349,9 @@ f2alaw_array (const float *ptr, int count, unsigned char *buffer, float normfact
 static inline void
 d2alaw_array (const double *ptr, int count, unsigned char *buffer, double normfact)
 {	while (--count >= 0)
-	{	if (ptr [count] >= 0)
+	{	if (!isfinite (ptr [count]))
+			buffer [count] = 0 ;
+		else if (ptr [count] >= 0)
 			buffer [count] = alaw_encode [lrint (normfact * ptr [count])] ;
 		else
 			buffer [count] = 0x7F & alaw_encode [- lrint (normfact * ptr [count])] ;

--- a/src/ulaw.c
+++ b/src/ulaw.c
@@ -19,6 +19,7 @@
 #include	"sfconfig.h"
 
 #include	<math.h>
+#include	<limits.h>
 
 #include	"sndfile.h"
 #include	"common.h"
@@ -827,7 +828,9 @@ s2ulaw_array (const short *ptr, int count, unsigned char *buffer)
 static inline void
 i2ulaw_array (const int *ptr, int count, unsigned char *buffer)
 {	while (--count >= 0)
-	{	if (ptr [count] >= 0)
+	{	if (ptr [count] == INT_MIN)
+			buffer [count] = ulaw_encode [INT_MAX >> (16 + 2)] ;
+		else if (ptr [count] >= 0)
 			buffer [count] = ulaw_encode [ptr [count] >> (16 + 2)] ;
 		else
 			buffer [count] = 0x7F & ulaw_encode [-ptr [count] >> (16 + 2)] ;
@@ -847,7 +850,9 @@ f2ulaw_array (const float *ptr, int count, unsigned char *buffer, float normfact
 static inline void
 d2ulaw_array (const double *ptr, int count, unsigned char *buffer, double normfact)
 {	while (--count >= 0)
-	{	if (ptr [count] >= 0)
+	{	if (!isfinite (ptr [count]))
+			buffer [count] = 0 ;
+		else if (ptr [count] >= 0)
 			buffer [count] = ulaw_encode [lrint (normfact * ptr [count])] ;
 		else
 			buffer [count] = 0x7F & ulaw_encode [- lrint (normfact * ptr [count])] ;


### PR DESCRIPTION
i2ulaw_array() and i2alaw_array() fail to handle ptr [count] = INT_MIN properly, leading to buffer underflow. INT_MIN is a special value since - INT_MIN cannot be represented as int.

In this case round - INT_MIN to INT_MAX and proceed as usual.

f2ulaw_array() and f2alaw_array() fail to handle ptr [count] = NaN properly, leading to null pointer dereference.

In this case, arbitrarily set the buffer value to 0.

Not sure 0 is the right value here.

This PR fixes #429 (CVE-2018-19661 + CVE-2018-19662), #344 (CVE-2017-17456 + CVE-2017-17457) and #317 (CVE-2017-14245 and CVE-2017-14246).