### PR TITLE
Fix EXT_SUBFORMAT struct

### DIFF
--- a/src/wavlike.h
+++ b/src/wavlike.h
@@ -267,7 +267,7 @@ typedef struct
 {	unsigned int	esf_field1 ;
 	unsigned short	esf_field2 ;
 	unsigned short	esf_field3 ;
-	char			esf_field4 [8] ;
+	unsigned char	esf_field4 [8] ;
 } EXT_SUBFORMAT ;
 
 typedef	struct


### PR DESCRIPTION
According to MSDN all the GUID fields are unsigned.

Fixes -Woverflow warnings in pedantic mode.