### PR TITLE
CMake: Fix warnings on MinGW platform

### DIFF
--- a/cmake/SndFileChecks.cmake
+++ b/cmake/SndFileChecks.cmake
@@ -174,7 +174,7 @@ if (WIN32)
 		set (WIN32_TARGET_DLL 1)
 	endif ()
 	if (MINGW)
-		set (__USE_MINGW_ANSI_STDIO 1)
+		add_definitions (-D__USE_MINGW_ANSI_STDIO=1)
 	endif ()
 endif ()
 

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -307,8 +307,5 @@
 /* Define to 1 if on MINIX. */
 #cmakedefine01 _MINIX
 
-/* Set to 1 to use C99 printf/snprintf in MinGW. */
-#cmakedefine01 __USE_MINGW_ANSI_STDIO
-
 /* Define as `__inline' or '__inline__' if that's what the C compiler calls it, or to nothing if it is not supported. */
 @INLINE_CODE@


### PR DESCRIPTION
Fixes warning: `"__USE_MINGW_ANSI_STDIO" redefined`.

`__USE_MINGW_ANSI_STDIO` is required to use 64-bit numbers in
    printf-like functions.