### PR TITLE
Vorbis: Use new ogg functions, bisection seek support.

### DIFF
--- a/src/ogg_vorbis.c
+++ b/src/ogg_vorbis.c
@@ -80,11 +80,12 @@
 
 typedef int convert_func (SF_PRIVATE *psf, int, void *, int, int, float **) ;
 
-static int	vorbis_read_header (SF_PRIVATE *psf, int log_data) ;
+static int	vorbis_read_header (SF_PRIVATE *psf) ;
 static int	vorbis_write_header (SF_PRIVATE *psf, int calc_length) ;
 static int	vorbis_close (SF_PRIVATE *psf) ;
 static int	vorbis_command (SF_PRIVATE *psf, int command, void *data, int datasize) ;
 static int	vorbis_byterate (SF_PRIVATE *psf) ;
+static sf_count_t	vorbis_calculate_page_duration (SF_PRIVATE *psf) ;
 static sf_count_t	vorbis_seek (SF_PRIVATE *psf, int mode, sf_count_t offset) ;
 static sf_count_t	vorbis_read_s (SF_PRIVATE *psf, short *ptr, sf_count_t len) ;
 static sf_count_t	vorbis_read_i (SF_PRIVATE *psf, int *ptr, sf_count_t len) ;
@@ -95,13 +96,15 @@ static sf_count_t	vorbis_write_i (SF_PRIVATE *psf, const int *ptr, sf_count_t le
 static sf_count_t	vorbis_write_f (SF_PRIVATE *psf, const float *ptr, sf_count_t len) ;
 static sf_count_t	vorbis_write_d (SF_PRIVATE *psf, const double *ptr, sf_count_t len) ;
 static sf_count_t	vorbis_read_sample (SF_PRIVATE *psf, void *ptr, sf_count_t lens, convert_func *transfn) ;
-static sf_count_t	vorbis_length (SF_PRIVATE *psf) ;
+static int	vorbis_rnull (SF_PRIVATE *psf, int samples, void *vptr, int off , int channels, float **pcm) ;
 
 typedef struct
 {	int id ;
 	const char *name ;
 } STR_PAIRS ;
 
+
+/* See https://xiph.org/vorbis/doc/v-comment.html */
 static STR_PAIRS vorbis_metatypes [] =
 {	{	SF_STR_TITLE,		"Title" },
 	{	SF_STR_COPYRIGHT,	"Copyright" },
@@ -129,64 +132,50 @@ typedef struct
 
 	/* Encoding quality in range [0.0, 1.0]. */
 	double quality ;
+
+	/* Current granule position. */
+	uint64_t pcm_current ;
+	/* Offset of the first samples' granule position. */
+	uint64_t pcm_start ;
+	/* Last valid samples' granule position. */
+	uint64_t pcm_end ;
+	/* File offset of the start of the last page. */
+	sf_count_t last_page ;
 } VORBIS_PRIVATE ;
 
 static int
-vorbis_read_header (SF_PRIVATE *psf, int log_data)
-{
-	OGG_PRIVATE *odata = (OGG_PRIVATE *) psf->container_data ;
+vorbis_read_header (SF_PRIVATE *psf)
+{	OGG_PRIVATE *odata = (OGG_PRIVATE *) psf->container_data ;
 	VORBIS_PRIVATE *vdata = (VORBIS_PRIVATE *) psf->codec_data ;
-	char *buffer ;
-	int	bytes ;
-	int i ;
-
-	odata->eos = 0 ;
+	sf_count_t duration ;
+	int printed_metadata_msg = 0 ;
+	int i, k, nn ;
 
 	/*
-	**	This function (vorbis_read_header) gets called multiple times, so the OGG
-	**	and vorbis structs have to be cleared every time we pass through to
-	**	prevent memory leaks.
-	*/
-	vorbis_block_clear (&vdata->vblock) ;
-	vorbis_dsp_clear (&vdata->vdsp) ;
-	vorbis_comment_clear (&vdata->vcomment) ;
-	vorbis_info_clear (&vdata->vinfo) ;
-
-	/*
+	**  The first page of the Ogg stream we are told to try and open as Vorbis
+	**  has already been loaded into odata->ostream by ogg_open().
+	**
 	**	Extract the initial header from the first page and verify that the
 	**	Ogg bitstream is in fact Vorbis data.
-	**
-	**	I handle the initial header first instead of just having the code
-	**	read all three Vorbis headers at once because reading the initial
-	**	header is an easy way to identify a Vorbis bitstream and it's
-	**	useful to see that functionality seperated out.
 	*/
+
 	vorbis_info_init (&vdata->vinfo) ;
 	vorbis_comment_init (&vdata->vcomment) ;
+
+	if (!odata->opacket.b_o_s)
+	{	psf_log_printf (psf, "Vorbis: First packet does not have a beginning-of-stream bit.\n") ;
+		return SFE_MALFORMED_FILE ;
+		}
+
+	if (ogg_stream_packetpeek (&odata->ostream, NULL))
+	{	psf_log_printf (psf, "Vorbis: First page contains extraneous packets!\n") ;
+		return SFE_MALFORMED_FILE ;
+		}
 
 	if (vorbis_synthesis_headerin (&vdata->vinfo, &vdata->vcomment, &odata->opacket) < 0)
 	{	/* Error case ; not a vorbis header. */
 		psf_log_printf (psf, "Found Vorbis in stream header, but vorbis_synthesis_headerin failed.\n") ;
 		return SFE_MALFORMED_FILE ;
-		} ;
-
-	/*
-	**	Common Ogg metadata fields?
-	**	TITLE, VERSION, ALBUM, TRACKNUMBER, ARTIST, PERFORMER, COPYRIGHT, LICENSE,
-	**	ORGANIZATION, DESCRIPTION, GENRE, DATE, LOCATION, CONTACT, ISRC,
-	*/
-
-	if (log_data)
-	{	int k ;
-
-		for (k = 0 ; k < ARRAY_LEN (vorbis_metatypes) ; k++)
-		{	char *dd ;
-
-			dd = vorbis_comment_query (&vdata->vcomment, vorbis_metatypes [k].name, 0) ;
-			if (dd == NULL)
-				continue ;
-			psf_store_string (psf, vorbis_metatypes [k].id, dd) ;
-			} ;
 		} ;
 
 	/*
@@ -203,74 +192,109 @@ vorbis_read_header (SF_PRIVATE *psf, int log_data)
 
 	i = 0 ;			/* Count of number of packets read */
 	while (i < 2)
-	{	int result = ogg_sync_pageout (&odata->osync, &odata->opage) ;
-		if (result == 0)
-		{	/* Need more data */
-			buffer = ogg_sync_buffer (&odata->osync, 4096) ;
-			bytes = psf_fread (buffer, 1, 4096, psf) ;
+	{	nn = ogg_stream_packetout (&odata->ostream, &odata->opacket) ;
 
-			if (bytes == 0 && i < 2)
+		if (nn == 0)
+		{	nn = ogg_stream_next_page (psf, odata) ;
+			if (nn == 0)
 			{	psf_log_printf (psf, "End of file before finding all Vorbis headers!\n") ;
 				return SFE_MALFORMED_FILE ;
 				} ;
-			ogg_sync_wrote (&odata->osync, bytes) ;
+			if (nn == -1)
+			{	psf_log_printf (psf, "Error reading file while finding Vorbis headers!\n") ;
+				return psf->error ;
+				} ;
+			continue ;
 			}
-		else if (result == 1)
-		{	/*
-			**	Don't complain about missing or corrupt data yet. We'll
-			**	catch it at the packet output phase.
-			**
-			**	We can ignore any errors here as they'll also become apparent
-			**	at packetout.
-			*/
-			ogg_stream_pagein (&odata->ostream, &odata->opage) ;
-			while (i < 2)
-			{	result = ogg_stream_packetout (&odata->ostream, &odata->opacket) ;
-				if (result == 0)
-					break ;
-				if (result < 0)
-				{	/*	Uh oh ; data at some point was corrupted or missing!
-					**	We can't tolerate that in a header. Die. */
-					psf_log_printf (psf, "Corrupt secondary header.	Exiting.\n") ;
-					return SFE_MALFORMED_FILE ;
-					} ;
 
-				vorbis_synthesis_headerin (&vdata->vinfo, &vdata->vcomment, &odata->opacket) ;
-				i++ ;
-				} ;
-			} ;
-		} ;
-
-	if (log_data)
-	{	int printed_metadata_msg = 0 ;
-		int k ;
-
-		psf_log_printf (psf, "Bitstream is %d channel, %D Hz\n", vdata->vinfo.channels, vdata->vinfo.rate) ;
-		psf_log_printf (psf, "Encoded by : %s\n", vdata->vcomment.vendor) ;
-
-		/* Throw the comments plus a few lines about the bitstream we're decoding. */
-		for (k = 0 ; k < ARRAY_LEN (vorbis_metatypes) ; k++)
-		{	char *dd ;
-
-			dd = vorbis_comment_query (&vdata->vcomment, vorbis_metatypes [k].name, 0) ;
-			if (dd == NULL)
-				continue ;
-
-			if (printed_metadata_msg == 0)
-			{	psf_log_printf (psf, "Metadata :\n") ;
-				printed_metadata_msg = 1 ;
-				} ;
-
-			psf_store_string (psf, vorbis_metatypes [k].id, dd) ;
-			psf_log_printf (psf, "  %-10s : %s\n", vorbis_metatypes [k].name, dd) ;
+		if (nn < 0)
+		{	/* A hole while reading headers. This could be bad. */
+			psf_log_printf (psf, "Corrupt secondary header.	Exiting.\n") ;
+			return SFE_MALFORMED_FILE ;
 			} ;
 
-		psf_log_printf (psf, "End\n") ;
+		vorbis_synthesis_headerin (&vdata->vinfo, &vdata->vcomment, &odata->opacket) ;
+		i++ ;
 		} ;
+
+	/* Check for extraneous packets in the last headers page. */
+	while (ogg_stream_packetout (&odata->ostream, &odata->opacket) == 1)
+	{	i++ ;
+		}
+	if (i > 2)
+		psf_log_printf (psf, "Vorbis: stream has extraneous header packets.\n") ;
+
+	psf_log_printf (psf, "Bitstream is %d channel, %D Hz\n", vdata->vinfo.channels, vdata->vinfo.rate) ;
+	psf_log_printf (psf, "Encoded by : %s\n", vdata->vcomment.vendor) ;
+
+	/* Save the offset of the first payload page */
+	psf->dataoffset	= ogg_sync_ftell (psf) ;
+
+	/*
+	** Caculate the granule position offset. The first page with a payload
+	** packet shouldn't end in a continued packet. The difference between the
+	** page's granule position and the sum of frames on the page tells us the
+	** granule position offset.
+	** See https://xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-132000A.2
+	*/
+	ogg_stream_unpack_page (psf, odata) ;
+	vdata->pcm_start = odata->pkt [odata->pkt_len - 1].granulepos ;
+	duration = vorbis_calculate_page_duration (psf) ;
+
+	if (duration < (sf_count_t) vdata->pcm_start)
+		vdata->pcm_start -= duration ;
+	else
+		vdata->pcm_start = 0 ;
+
+	vdata->loc = vdata->pcm_start ;
+	vdata->pcm_end = (uint64_t) -1 ;
+	psf->datalength = psf->filelength ;
+	if (psf->sf.seekable)
+	{	sf_count_t last_page ;
+		sf_count_t saved_offset ;
+
+		saved_offset = ogg_sync_ftell (psf) ;
+		last_page = ogg_sync_last_page_before (psf, odata, &vdata->pcm_end, psf->filelength, odata->ostream.serialno) ;
+		if (last_page > 0)
+		{	if (!ogg_page_eos (&odata->opage))
+				psf_log_printf (psf, "Ogg: Last page lacks an end-of-stream bit.\n") ;
+			psf->datalength = last_page + odata->opage.header_len + odata->opage.body_len - psf->dataoffset ;
+			if (psf->datalength + psf->dataoffset < psf->filelength)
+				psf_log_printf (psf, "Ogg: Junk after the last page.\n") ;
+			vdata->last_page = last_page ;
+			} ;
+
+		ogg_sync_fseek (psf, saved_offset, SEEK_SET) ;
+		}
+
+	psf_log_printf (psf, "PCM offset  : %d\n", vdata->pcm_start) ;
+	if (vdata->pcm_end != (uint64_t) -1)
+		psf_log_printf (psf, "PCM end     : %d\n", vdata->pcm_end) ;
+	else
+		psf_log_printf (psf, "PCM end     : unknown\n") ;
+
+	/* Throw the comments plus a few lines about the bitstream we're decoding. */
+	for (k = 0 ; k < ARRAY_LEN (vorbis_metatypes) ; k++)
+	{	char *dd ;
+
+		dd = vorbis_comment_query (&vdata->vcomment, vorbis_metatypes [k].name, 0) ;
+		if (dd == NULL)
+			continue ;
+
+		if (printed_metadata_msg == 0)
+		{	psf_log_printf (psf, "Metadata :\n") ;
+			printed_metadata_msg = 1 ;
+			} ;
+
+		psf_store_string (psf, vorbis_metatypes [k].id, dd) ;
+		psf_log_printf (psf, "  %-10s : %s\n", vorbis_metatypes [k].name, dd) ;
+		} ;
+	psf_log_printf (psf, "End\n") ;
 
 	psf->sf.samplerate	= vdata->vinfo.rate ;
 	psf->sf.channels	= vdata->vinfo.channels ;
 	psf->sf.format		= SF_FORMAT_OGG | SF_FORMAT_VORBIS ;
+	psf->sf.frames		= (vdata->pcm_end != (uint64_t) -1) ? vdata->pcm_end - vdata->pcm_start : SF_COUNT_MAX ;
 
 	/*	OK, got and parsed all three headers. Initialize the Vorbis
 	**	packet->PCM decoder.
@@ -281,8 +305,6 @@ vorbis_read_header (SF_PRIVATE *psf, int log_data)
 	**	proceed in parallel. We could init multiple vorbis_block structures
 	**	for vd here. */
 	vorbis_block_init (&vdata->vdsp, &vdata->vblock) ;
-
-	vdata->loc = 0 ;
 
 	return 0 ;
 } /* vorbis_read_header */
@@ -372,8 +394,7 @@ vorbis_write_header (SF_PRIVATE *psf, int UNUSED (calc_length))
 		 * audio data will start on a new page, as per spec
 		 */
 		while ((result = ogg_stream_flush (&odata->ostream, &odata->opage)) != 0)
-		{	psf_fwrite (odata->opage.header, 1, odata->opage.header_len, psf) ;
-			psf_fwrite (odata->opage.body, 1, odata->opage.body_len, psf) ;
+		{	ogg_write_page (psf, &odata->opage) ;
 			} ;
 	}
 
@@ -412,8 +433,7 @@ vorbis_close (SF_PRIVATE *psf)
 				while (!odata->eos)
 				{	int result = ogg_stream_pageout (&odata->ostream, &odata->opage) ;
 					if (result == 0) break ;
-					psf_fwrite (odata->opage.header, 1, odata->opage.header_len, psf) ;
-					psf_fwrite (odata->opage.body, 1, odata->opage.body_len, psf) ;
+					ogg_write_page (psf, &odata->opage) ;
 
 		/* this could be set above, but for illustrative purposes, I do
 		   it here (to show that vorbis does know where the stream ends) */
@@ -455,18 +475,13 @@ ogg_vorbis_open (SF_PRIVATE *psf)
 	psf_log_printf (psf, "Vorbis library version : %s\n", vorbis_version_string ()) ;
 
 	if (psf->file.mode == SFM_READ)
-	{	/*
-		** First page of the ogg stream is already loaded by the ogg container
-		** when it classified the stream, no need to reload it.
-		*/
-		if ((error = vorbis_read_header (psf, 1)))
+	{	if ((error = vorbis_read_header (psf)))
 			return error ;
 
 		psf->read_short		= vorbis_read_s ;
 		psf->read_int		= vorbis_read_i ;
 		psf->read_float		= vorbis_read_f ;
 		psf->read_double	= vorbis_read_d ;
-		psf->sf.frames		= vorbis_length (psf) ;
 		} ;
 
 	psf->codec_close = vorbis_close ;
@@ -493,8 +508,13 @@ ogg_vorbis_open (SF_PRIVATE *psf)
 	psf->sf.format = SF_FORMAT_OGG | SF_FORMAT_VORBIS ;
 	psf->sf.sections = 1 ;
 
-	psf->datalength = 1 ;
-	psf->dataoffset = 0 ;
+	if (psf->dataoffset != -1)
+		psf->datalength = psf->filelength - psf->dataoffset ;
+	else
+	{	psf->datalength = 1 ;
+		psf->dataoffset = 0 ;
+		} ;
+
 	/* End FIXME. */
 
 	return error ;
@@ -601,81 +621,50 @@ vorbis_rdouble (SF_PRIVATE *UNUSED (psf), int samples, void *vptr, int off, int 
 
 static sf_count_t
 vorbis_read_sample (SF_PRIVATE *psf, void *ptr, sf_count_t lens, convert_func *transfn)
-{
-	VORBIS_PRIVATE *vdata = psf->codec_data ;
+{	VORBIS_PRIVATE *vdata = psf->codec_data ;
 	OGG_PRIVATE *odata = psf->container_data ;
-	int len, samples, i = 0 ;
+	int len, samples, i = 0 , nn ;
 	float **pcm ;
 
 	len = lens / psf->sf.channels ;
 
-	while ((samples = vorbis_synthesis_pcmout (&vdata->vdsp, &pcm)) > 0)
-	{	if (samples > len) samples = len ;
-		i += transfn (psf, samples, ptr, i, psf->sf.channels, pcm) ;
-		len -= samples ;
-		/* tell libvorbis how many samples we actually consumed */
-		vorbis_synthesis_read (&vdata->vdsp, samples) ;
-		vdata->loc += samples ;
-		if (len == 0)
-			return i ; /* Is this necessary */
-	}
-	goto start0 ;		/* Jump into the nasty nest */
-	while (len > 0 && !odata->eos)
-	{
-		while (len > 0 && !odata->eos)
-		{	int result = ogg_sync_pageout (&odata->osync, &odata->opage) ;
-			if (result == 0) break ; /* need more data */
-			if (result < 0)
-			{	/* missing or corrupt data at this page position */
-				psf_log_printf (psf, "Corrupt or missing data in bitstream ; continuing...\n") ;
-				}
-			else
-			{	/* can safely ignore errors at this point */
-				ogg_stream_pagein (&odata->ostream, &odata->opage) ;
-			start0:
-				while (1)
-				{	result = ogg_stream_packetout (&odata->ostream, &odata->opacket) ;
-					if (result == 0)
-						break ; /* need more data */
-					if (result < 0)
-					{	/* missing or corrupt data at this page position */
-						/* no reason to complain ; already complained above */
-						}
-					else
-					{	/* we have a packet.	Decode it */
-						if (vorbis_synthesis (&vdata->vblock, &odata->opacket) == 0) /* test for success! */
-							vorbis_synthesis_blockin (&vdata->vdsp, &vdata->vblock) ;
-						/*
-						** pcm is a multichannel float vector.	 In stereo, for
-						** example, pcm [0] is left, and pcm [1] is right.	 samples is
-						** the size of each channel.	 Convert the float values
-						** (-1.<=range<=1.) to whatever PCM format and write it out.
-						*/
+	while (len > 0)
+	{	/*
+		** pcm is a multichannel float vector.	 In stereo, for
+		** example, pcm [0] is left, and pcm [1] is right.	 samples is
+		** the size of each channel.	 Convert the float values
+		** (-1.<=range<=1.) to whatever PCM format and write it out.
+		*/
+		while ((samples = vorbis_synthesis_pcmout (&vdata->vdsp, &pcm)) > 0)
+		{	if (samples > len) samples = len ;
+			i += transfn (psf, samples, ptr, i, psf->sf.channels, pcm) ;
+			len -= samples ;
+			/* tell libvorbis how many samples we actually consumed */
+			vorbis_synthesis_read (&vdata->vdsp, samples) ;
+			vdata->loc += samples ;
+			if (len == 0)
+				return i ; /* Is this necessary */
+			} ;
 
-						while ((samples = vorbis_synthesis_pcmout (&vdata->vdsp, &pcm)) > 0)
-						{	if (samples > len) samples = len ;
-							i += transfn (psf, samples, ptr, i, psf->sf.channels, pcm) ;
-							len -= samples ;
-							/* tell libvorbis how many samples we actually consumed */
-							vorbis_synthesis_read (&vdata->vdsp, samples) ;
-							vdata->loc += samples ;
-							if (len == 0)
-								return i ; /* Is this necessary */
-							} ;
-					}
+		/* Out of samples, load the next packet. */
+		if (odata->pkt_indx == odata->pkt_len)
+		{	/* Page out of packets, load and unpack the next page. */
+			nn = ogg_stream_unpack_page (psf, odata) ;
+			if (nn <= 0)
+				return i ;
+			if (nn == 2)
+			{	/* Ran over a hole. loc is now out of date, need to recalculate. */
+				vdata->loc = odata->pkt [odata->pkt_len - 1].granulepos ;
+				vdata->loc -= vorbis_calculate_page_duration (psf) ;
 				}
-				if (ogg_page_eos (&odata->opage)) odata->eos = 1 ;
-			}
-		}
-		if (!odata->eos)
-		{	char *buffer ;
-			int bytes ;
-			buffer = ogg_sync_buffer (&odata->osync, 4096) ;
-			bytes = psf_fread (buffer, 1, 4096, psf) ;
-			ogg_sync_wrote (&odata->osync, bytes) ;
-			if (bytes == 0) odata->eos = 1 ;
-		}
-	}
+			} ;
+
+		/* Decode the packet */
+		if (vorbis_synthesis (&vdata->vblock, &(odata->pkt [odata->pkt_indx])) == 0) /* test for success! */
+			vorbis_synthesis_blockin (&vdata->vdsp, &vdata->vblock) ;
+		odata->pkt_indx++ ;
+		} ;
+
 	return i ;
 } /* vorbis_read_sample */
 
@@ -728,8 +717,7 @@ vorbis_write_samples (SF_PRIVATE *psf, OGG_PRIVATE *odata, VORBIS_PRIVATE *vdata
 			{	int result = ogg_stream_pageout (&odata->ostream, &odata->opage) ;
 				if (result == 0)
 					break ;
-				psf_fwrite (odata->opage.header, 1, odata->opage.header_len, psf) ;
-				psf_fwrite (odata->opage.body, 1, odata->opage.body_len, psf) ;
+				ogg_write_page (psf, &odata->opage) ;
 
 				/*	This could be set above, but for illustrative purposes, I do
 				**	it here (to show that vorbis does know where the stream ends) */
@@ -810,9 +798,10 @@ vorbis_write_d (SF_PRIVATE *psf, const double *ptr, sf_count_t lens)
 
 static sf_count_t
 vorbis_seek (SF_PRIVATE *psf, int UNUSED (mode), sf_count_t offset)
-{
-	OGG_PRIVATE *odata = (OGG_PRIVATE *) psf->container_data ;
+{	OGG_PRIVATE *odata = (OGG_PRIVATE *) psf->container_data ;
 	VORBIS_PRIVATE *vdata = (VORBIS_PRIVATE *) psf->codec_data ;
+	sf_count_t target ;
+	int ret ;
 
 	if (odata == NULL || vdata == NULL)
 		return 0 ;
@@ -823,11 +812,40 @@ vorbis_seek (SF_PRIVATE *psf, int UNUSED (mode), sf_count_t offset)
 		} ;
 
 	if (psf->file.mode == SFM_READ)
-	{	sf_count_t target = offset - vdata->loc ;
+	{	target = offset + vdata->pcm_start ;
 
-		if (target < 0)
-		{	ogg_read_first_page (psf, odata) ;
-			vorbis_read_header (psf, 0) ; /* Reset state */
+		/*
+		** If the end of the file is know, and the seek isn't for the near
+		** future, do a search of the file for a good place to start.
+		*/
+		ret = 0 ;
+		if ((vdata->pcm_end != (uint64_t) -1) &&
+			(target < vdata->loc || target - vdata->loc > (2 * psf->sf.samplerate)))
+		{	uint64_t best_gp ;
+
+			best_gp = vdata->pcm_start ;
+
+			ret = ogg_stream_seek_page_search (psf, odata, target, vdata->pcm_start,
+				vdata->pcm_end, &best_gp, psf->dataoffset, vdata->last_page) ;
+			if (ret >= 0)
+			{	ret = ogg_stream_unpack_page (psf, odata) ;
+				if (ret == 1)
+				{	vdata->loc = best_gp ;
+					vorbis_synthesis_restart (&vdata->vdsp) ;
+					} ;
+				} ;
+			} ;
+
+		if (ret >= 0 && offset + (sf_count_t) vdata->pcm_start >= vdata->loc)
+			target = offset + vdata->pcm_start - vdata->loc ;
+		else
+		{	/* Search failed (bad data?), reset to the beginning of the stream. */
+			ogg_stream_reset_serialno (&odata->ostream, odata->ostream.serialno) ;
+			odata->pkt_len = 0 ;
+			odata->pkt_indx = 0 ;
+			ogg_sync_fseek (psf, psf->dataoffset, SEEK_SET) ;
+			vdata->loc = 0 ;
+			vorbis_synthesis_restart (&vdata->vdsp) ;
 			target = offset ;
 			} ;
 
@@ -844,7 +862,7 @@ vorbis_seek (SF_PRIVATE *psf, int UNUSED (mode), sf_count_t offset)
 			target -= m ;
 			} ;
 
-		return vdata->loc ;
+		return vdata->loc - vdata->pcm_start ;
 		} ;
 
 	return 0 ;
@@ -860,260 +878,27 @@ vorbis_byterate (SF_PRIVATE *psf)
 	return -1 ;
 } /* vorbis_byterate */
 
-/*==============================================================================
-**	Most of the following code was snipped from Mike Smith's ogginfo utility
-**	which is part of vorbis-tools.
-**	Vorbis tools is released under the GPL but Mike has kindly allowed the
-**	following to be relicensed as LGPL for libsndfile.
-*/
-
-typedef struct
-{
-	int isillegal ;
-	int shownillegal ;
-	int isnew ;
-	int end ;
-
-	uint32_t serial ; /* must be 32 bit unsigned */
-	ogg_stream_state ostream ;
-
-	vorbis_info vinfo ;
-	vorbis_comment vcomment ;
-	sf_count_t lastgranulepos ;
-	int doneheaders ;
-} stream_processor ;
-
-typedef struct
-{
-	stream_processor *streams ;
-	int allocated ;
-	int used ;
-	int in_headers ;
-} stream_set ;
-
-static stream_set *
-create_stream_set (void)
-{	stream_set *set = calloc (1, sizeof (stream_set)) ;
-
-	set->streams = calloc (5, sizeof (stream_processor)) ;
-	set->allocated = 5 ;
-	set->used = 0 ;
-
-	return set ;
-} /* create_stream_set */
-
-static void
-vorbis_end (stream_processor *stream, sf_count_t * len)
-{	*len += stream->lastgranulepos ;
-	vorbis_comment_clear (&stream->vcomment) ;
-	vorbis_info_clear (&stream->vinfo) ;
-} /* vorbis_end */
-
-static void
-free_stream_set (stream_set *set, sf_count_t * len)
-{	int i ;
-
-	for (i = 0 ; i < set->used ; i++)
-	{	if (!set->streams [i].end)
-			vorbis_end (&set->streams [i], len) ;
-		ogg_stream_clear (&set->streams [i].ostream) ;
-		} ;
-
-	free (set->streams) ;
-	free (set) ;
-} /* free_stream_set */
-
-static int
-streams_open (stream_set *set)
-{	int i, res = 0 ;
-
-	for (i = 0 ; i < set->used ; i++)
-		if (!set->streams [i].end)
-			res ++ ;
-	return res ;
-} /* streams_open */
-
-static stream_processor *
-find_stream_processor (stream_set *set, ogg_page *page)
-{	uint32_t serial = ogg_page_serialno (page) ;
-	int i, invalid = 0 ;
-
-	stream_processor *stream ;
-
-	for (i = 0 ; i < set->used ; i++)
-	{
-		if (serial == set->streams [i].serial)
-		{	/* We have a match! */
-			stream = & (set->streams [i]) ;
-
-			set->in_headers = 0 ;
-			/* if we have detected EOS, then this can't occur here. */
-			if (stream->end)
-			{	stream->isillegal = 1 ;
-				return stream ;
-				}
-
-			stream->isnew = 0 ;
-			stream->end = ogg_page_eos (page) ;
-			stream->serial = serial ;
-			return stream ;
-			} ;
-		} ;
-
-	/* If there are streams open, and we've reached the end of the
-	** headers, then we can't be starting a new stream.
-	** XXX: might this sometimes catch ok streams if EOS flag is missing,
-	** but the stream is otherwise ok?
-	*/
-	if (streams_open (set) && !set->in_headers)
-		invalid = 1 ;
-
-	set->in_headers = 1 ;
-
-	if (set->allocated < set->used)
-		stream = &set->streams [set->used] ;
-	else
-	{	set->allocated += 5 ;
-		set->streams = realloc (set->streams, sizeof (stream_processor) * set->allocated) ;
-		stream = &set->streams [set->used] ;
-		} ;
-
-	set->used++ ;
-
-	stream->isnew = 1 ;
-	stream->isillegal = invalid ;
-
-	{
-		int res ;
-		ogg_packet packet ;
-
-		/* We end up processing the header page twice, but that's ok. */
-		ogg_stream_init (&stream->ostream, serial) ;
-		ogg_stream_pagein (&stream->ostream, page) ;
-		res = ogg_stream_packetout (&stream->ostream, &packet) ;
-		if (res <= 0)
-			return NULL ;
-		else if (packet.bytes >= 7 && memcmp (packet.packet, "\x01vorbis", 7) == 0)
-		{
-			stream->lastgranulepos = 0 ;
-			vorbis_comment_init (&stream->vcomment) ;
-			vorbis_info_init (&stream->vinfo) ;
-			} ;
-
-		res = ogg_stream_packetout (&stream->ostream, &packet) ;
-
-		/* re-init, ready for processing */
-		ogg_stream_clear (&stream->ostream) ;
-		ogg_stream_init (&stream->ostream, serial) ;
-	}
-
-	stream->end = ogg_page_eos (page) ;
-	stream->serial = serial ;
-
-	return stream ;
-} /* find_stream_processor */
-
-static int
-vorbis_length_get_next_page (SF_PRIVATE *psf, ogg_sync_state * osync, ogg_page *page)
-{	static const int CHUNK_SIZE = 4500 ;
-
-	while (ogg_sync_pageout (osync, page) <= 0)
-	{	char * buffer = ogg_sync_buffer (osync, CHUNK_SIZE) ;
-		int bytes = psf_fread (buffer, 1, 4096, psf) ;
-
-		if (bytes <= 0)
-		{	ogg_sync_wrote (osync, 0) ;
-			return 0 ;
-			} ;
-
-		ogg_sync_wrote (osync, bytes) ;
-		} ;
-
-	return 1 ;
-} /* vorbis_length_get_next_page */
-
 static sf_count_t
-vorbis_length_aux (SF_PRIVATE * psf)
-{
-	ogg_sync_state osync ;
-	ogg_page page ;
-	sf_count_t len = 0 ;
-	stream_set *processors ;
+vorbis_calculate_page_duration (SF_PRIVATE *psf)
+{	OGG_PRIVATE *odata = (OGG_PRIVATE *) psf->container_data ;
+	VORBIS_PRIVATE *vdata = (VORBIS_PRIVATE *) psf->codec_data ;
+	long thisblock, lastblock ;
+	sf_count_t duration ;
+	int i ;
 
-	processors = create_stream_set () ;
-	if (processors == NULL)
-		return 0 ;	// out of memory?
-
-	ogg_sync_init (&osync) ;
-
-	while (vorbis_length_get_next_page (psf, &osync, &page))
-	{
-		stream_processor *p = find_stream_processor (processors, &page) ;
-
-		if (!p)
-		{	len = 0 ;
-			break ;
-			} ;
-
-		if (p->isillegal && !p->shownillegal)
-		{
-			p->shownillegal = 1 ;
-			/* If it's a new stream, we want to continue processing this page
-			** anyway to suppress additional spurious errors
-			*/
-			if (!p->isnew) continue ;
-			} ;
-
-		if (!p->isillegal)
-		{	ogg_packet packet ;
-			int header = 0 ;
-
-			ogg_stream_pagein (&p->ostream, &page) ;
-			if (p->doneheaders < 3)
-				header = 1 ;
-
-			while (ogg_stream_packetout (&p->ostream, &packet) > 0)
-			{
-				if (p->doneheaders < 3)
-				{	if (vorbis_synthesis_headerin (&p->vinfo, &p->vcomment, &packet) < 0)
-						continue ;
-					p->doneheaders ++ ;
-					} ;
-				} ;
-			if (!header)
-			{	sf_count_t gp = ogg_page_granulepos (&page) ;
-				if (gp > 0) p->lastgranulepos = gp ;
-				} ;
-			if (p->end)
-			{	vorbis_end (p, &len) ;
-				p->isillegal = 1 ;
-				} ;
+	lastblock = -1 ;
+	duration = 0 ;
+	for (i = 0 ; i < odata->pkt_len ; i++)
+	{	thisblock = vorbis_packet_blocksize (&vdata->vinfo, &(odata->pkt [i])) ;
+		if (thisblock >= 0)
+		{	if (lastblock != -1)
+				duration += (lastblock + thisblock) >> 2 ;
+			lastblock = thisblock ;
 			} ;
 		} ;
 
-	ogg_sync_clear (&osync) ;
-	free_stream_set (processors, &len) ;
-
-	return len ;
-} /* vorbis_length_aux */
-
-static sf_count_t
-vorbis_length (SF_PRIVATE *psf)
-{	sf_count_t length ;
-	int error ;
-
-	if (psf->sf.seekable == 0)
-		return SF_COUNT_MAX ;
-
-	psf_fseek (psf, 0, SEEK_SET) ;
-	length = vorbis_length_aux (psf) ;
-
-	if ((error = ogg_read_first_page (psf, (OGG_PRIVATE *) psf->container_data)) != 0 ||
-		(error = vorbis_read_header (psf, 0)) != 0)
-		psf->error = error ;
-
-	return length ;
-} /* vorbis_length */
+	return duration ;
+}
 
 #else /* HAVE_EXTERNAL_XIPH_LIBS */
 


### PR DESCRIPTION
Use new Ogg functionality merged with Opus support to reduce code duplication, simplify Vorbis support (decoding in particular) and improve seek performance.

This uses the bisection-based seek support, rather than decode-from-start seeking. This removes the need for a separate file decode for calculating file sample count. The 'nasty nest' is simplified and flattened out a bit.

No new tests are introduced, as no new functionality is exposed (other than less computationally expensive seeking.)

Had this on the back-burner ready to go once the Ogg changes required by the Opus pull request were merged.