### PR TITLE
Increase arbitrary channel limit

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -116,7 +116,7 @@
 #define		COMPILE_TIME_ASSERT(e)	(sizeof (struct { int : - !! (e) ; }))
 
 
-#define		SF_MAX_CHANNELS		1024
+#define		SF_MAX_CHANNELS		32766
 
 
 /*


### PR DESCRIPTION
Increased SF_MAX_CHANNELS to be 32766 (2^15 - 2). One less than the
largest number that can be supported by a signed 2-byte integer, which
is what I determined is the largest size supported by all formats.

The reason is 2^15 - 2 instead of 2^15 - 1 is because of less-than
comparisons that could probably be less-than-equal-to.

The previous limit of 1024 is arbitrary, and many formats support much
more than that.