### PR TITLE
Fix zero-as-null-pointer-constant-warning

### DIFF
--- a/src/sndfile.hh
+++ b/src/sndfile.hh
@@ -57,6 +57,12 @@
 #include <string>
 #include <new> // for std::nothrow
 
+#if __cplusplus < 201100
+#ifndef nullptr
+#define nullptr NULL
+#endif
+#endif
+
 class SndfileHandle
 {	private :
 		struct SNDFILE_ref
@@ -72,7 +78,7 @@ class SndfileHandle
 
 	public :
 			/* Default constructor */
-			SndfileHandle (void) : p (NULL) {} ;
+			SndfileHandle (void) : p (nullptr) {} ;
 			SndfileHandle (const char *path, int mode = SFM_READ,
 							int format = 0, int channels = 0, int samplerate = 0) ;
 			SndfileHandle (std::string const & path, int mode = SFM_READ,
@@ -93,9 +99,9 @@ class SndfileHandle
 			SndfileHandle & operator = (const SndfileHandle &rhs) ;
 
 		/* Mainly for debugging/testing. */
-		int refCount (void) const { return (p == NULL) ? 0 : p->ref ; }
+		int refCount (void) const { return (p == nullptr) ? 0 : p->ref ; }
 
-		operator bool () const { return (p != NULL) ; }
+		operator bool () const { return (p != nullptr) ; }
 
 		bool operator == (const SndfileHandle &rhs) const { return (p == rhs.p) ; }
 
@@ -155,20 +161,20 @@ class SndfileHandle
 
 inline
 SndfileHandle::SNDFILE_ref::SNDFILE_ref (void)
-: sf (NULL), sfinfo (), ref (1)
+: sf (nullptr), sfinfo (), ref (1)
 {}
 
 inline
 SndfileHandle::SNDFILE_ref::~SNDFILE_ref (void)
-{	if (sf != NULL) sf_close (sf) ; }
+{	if (sf != nullptr) sf_close (sf) ; }
 
 inline
 SndfileHandle::SndfileHandle (const char *path, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (nullptr)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != nullptr)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -186,11 +192,11 @@ SndfileHandle::SndfileHandle (const char *path, int mode, int fmt, int chans, in
 
 inline
 SndfileHandle::SndfileHandle (std::string const & path, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (nullptr)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != nullptr)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -208,14 +214,14 @@ SndfileHandle::SndfileHandle (std::string const & path, int mode, int fmt, int c
 
 inline
 SndfileHandle::SndfileHandle (int fd, bool close_desc, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (nullptr)
 {
 	if (fd < 0)
 		return ;
 
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != nullptr)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -233,11 +239,11 @@ SndfileHandle::SndfileHandle (int fd, bool close_desc, int mode, int fmt, int ch
 
 inline
 SndfileHandle::SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (nullptr)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != nullptr)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;
@@ -255,7 +261,7 @@ SndfileHandle::SndfileHandle (SF_VIRTUAL_IO &sfvirtual, void *user_data, int mod
 
 inline
 SndfileHandle::~SndfileHandle (void)
-{	if (p != NULL && --p->ref == 0)
+{	if (p != nullptr && --p->ref == 0)
 		delete p ;
 } /* SndfileHandle destructor */
 
@@ -263,7 +269,7 @@ SndfileHandle::~SndfileHandle (void)
 inline
 SndfileHandle::SndfileHandle (const SndfileHandle &orig)
 : p (orig.p)
-{	if (p != NULL)
+{	if (p != nullptr)
 		++p->ref ;
 } /* SndfileHandle copy constructor */
 
@@ -272,11 +278,11 @@ SndfileHandle::operator = (const SndfileHandle &rhs)
 {
 	if (&rhs == this)
 		return *this ;
-	if (p != NULL && --p->ref == 0)
+	if (p != nullptr && --p->ref == 0)
 		delete p ;
 
 	p = rhs.p ;
-	if (p != NULL)
+	if (p != nullptr)
 		++p->ref ;
 
 	return *this ;
@@ -401,18 +407,18 @@ SndfileHandle::writeRaw (const void *ptr, sf_count_t bytes)
 
 inline SNDFILE *
 SndfileHandle::rawHandle (void)
-{	return (p ? p->sf : NULL) ; }
+{	return (p ? p->sf : nullptr) ; }
 
 inline SNDFILE *
 SndfileHandle::takeOwnership (void)
 {
-	if (p == NULL || (p->ref != 1))
-		return NULL ;
+	if (p == nullptr || (p->ref != 1))
+		return nullptr ;
 
 	SNDFILE * sf = p->sf ;
-	p->sf = NULL ;
+	p->sf = nullptr ;
 	delete p ;
-	p = NULL ;
+	p = nullptr ;
 	return sf ;
 }
 
@@ -420,11 +426,11 @@ SndfileHandle::takeOwnership (void)
 
 inline
 SndfileHandle::SndfileHandle (LPCWSTR wpath, int mode, int fmt, int chans, int srate)
-: p (NULL)
+: p (nullptr)
 {
 	p = new (std::nothrow) SNDFILE_ref () ;
 
-	if (p != NULL)
+	if (p != nullptr)
 	{	p->ref = 1 ;
 
 		p->sfinfo.frames = 0 ;


### PR DESCRIPTION
This PR simply replace 0 or NULL by nullptr. It allow compiling the code with the following compiler flags:

```
-Werror -Wzero-as-null-pointer-constant
```