### PR TITLE
Fix Package Configuration file when ENABLE_EXTERNAL_LIBS is OFF

### DIFF
--- a/cmake/SndFileConfig.cmake.in
+++ b/cmake/SndFileConfig.cmake.in
@@ -9,10 +9,12 @@ set (SndFile_WITH_EXTERNAL_LIBS @SndFile_WITH_EXTERNAL_LIBS@)
 
 include (CMakeFindDependencyMacro)
 
-find_dependency (Ogg 1.3)
-find_dependency (VorbisEnc)
-find_dependency (FLAC)
-find_dependency (Opus)
+if (SndFile_WITH_EXTERNAL_LIBS AND NOT @BUILD_SHARED_LIBS@)
+	find_dependency (Ogg 1.3)
+	find_dependency (VorbisEnc)
+	find_dependency (FLAC)
+	find_dependency (Opus)
+endif ()
 
 include (${CMAKE_CURRENT_LIST_DIR}/SndFileTargets.cmake)
 


### PR DESCRIPTION
When libsndfile is configured with `ENABLE_EXTERNAL_LIBS=OFF`, the CMake Package Configuration file shouldn't look for the external libraries. Otherwise, the `return()` call in the `find_dependency()` macro causes `find_package(SndFile)` to fail if the libraries are not found.