### PR TITLE
sfe_copy_data_fp: check value of "max" variable for being normal

### DIFF
--- a/programs/common.h
+++ b/programs/common.h
@@ -67,7 +67,7 @@ typedef SF_BROADCAST_INFO_VAR (2048) SF_BROADCAST_INFO_2K ;
 
 void sfe_apply_metadata_changes (const char * filenames [2], const METADATA_INFO * info) ;
 
-void sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize) ;
+int sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize) ;
 
 void sfe_copy_data_int (SNDFILE *outfile, SNDFILE *infile, int channels) ;
 

--- a/programs/sndfile-convert.c
+++ b/programs/sndfile-convert.c
@@ -355,7 +355,11 @@ main (int argc, char * argv [])
 			|| (infileminor == SF_FORMAT_DOUBLE) || (infileminor == SF_FORMAT_FLOAT)
 			|| (infileminor == SF_FORMAT_OPUS) || (outfileminor == SF_FORMAT_OPUS)
 			|| (infileminor == SF_FORMAT_VORBIS) || (outfileminor == SF_FORMAT_VORBIS))
-		sfe_copy_data_fp (outfile, infile, sfinfo.channels, normalize) ;
+	{	if (sfe_copy_data_fp (outfile, infile, sfinfo.channels, normalize) != 0)
+		{	printf ("Error : Not able to decode input file %s.\n", infilename) ;
+			return 1 ;
+			} ;
+		}
 	else
 		sfe_copy_data_int (outfile, infile, sfinfo.channels) ;
 


### PR DESCRIPTION
and check elements of the data[] array for being finite.

Both checks use functions provided by the <math.h> header as declared
by the C99 standard.

Fixes #317
CVE-2017-14245
CVE-2017-14246