### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/ms_adpcm.c
+++ b/src/ms_adpcm.c
@@ -520,7 +520,8 @@ static int
 msadpcm_encode_block	(SF_PRIVATE *psf, MSADPCM_PRIVATE *pms)
 {	unsigned int	blockindx ;
 	unsigned char	byte ;
-	int				chan, k, predict, bpred [2], idelta [2], errordelta, newsamp ;
+	int				chan, k, predict, bpred [2] = { 0 }, idelta [2] = { 0 },
+					errordelta, newsamp ;
 
 	choose_predictor (pms->channels, pms->samples, bpred, idelta) ;
 

--- a/src/ogg.c
+++ b/src/ogg.c
@@ -168,7 +168,7 @@ ogg_read_first_page (SF_PRIVATE *psf, OGG_PRIVATE *odata)
 	memcpy (buffer, psf->header.ptr, psf->header.indx) ;
 	ogg_sync_wrote (&odata->osync, psf->header.indx) ;
 
-	ret = ogg_sync_next_page (psf, &odata->opage, SF_MAX (0l, 4096 - psf->header.indx), NULL) ;
+	ret = ogg_sync_next_page (psf, &odata->opage, SF_MAX ((sf_count_t) 0, 4096 - psf->header.indx), NULL) ;
 
 	/* Have we simply run out of data?  If so, we're done. */
 	if (ret == 0)
@@ -570,7 +570,7 @@ ogg_stream_seek_page_search (SF_PRIVATE *psf, OGG_PRIVATE *odata, uint64_t targe
 			next_boundary = SF_MIN (page_offset, next_boundary) ;
 
 			/* If not from our stream, continue. */
-			if (odata->ostream.serialno != (uint32_t) ogg_page_serialno (&page))
+			if (odata->ostream.serialno != ogg_page_serialno (&page))
 				continue ;
 
 			/*

--- a/tests/misc_test.c
+++ b/tests/misc_test.c
@@ -260,16 +260,17 @@ zero_data_test (const char *filename, int format)
 
 static void
 filesystem_full_test (int format)
-{	SNDFILE		*file ;
+{
+#if (defined (WIN32) || defined (_WIN32))
+	(void) format ;
+	/* Can't run this test on Win32 so return. */
+	return ;
+#else
+	SNDFILE		*file ;
 	SF_INFO		sfinfo ;
 	struct stat buf ;
 
 	const char	*filename = "/dev/full", *errorstr ;
-
-#if (defined (WIN32) || defined (_WIN32))
-	/* Can't run this test on Win32 so return. */
-	return ;
-#else
 
 	/* Make sure errno is zero before doing anything else. */
 	errno = 0 ;


### PR DESCRIPTION
Fix GCC 10.2.0 with `-Wall -Wextra` warnings.

1. src/ogg.c: Fix compiler warning

   -Wsign-compare in ogg_stream_seek_page_search().

2. src/misc_test.c: Fix compiler warnings

   -Wunused-parameter, -Wunused-variable in filesystem_full_test().

   Windows platforms only.

3. src/ms_adpcm.c: Fix compiler warnings

   -Wmaybe-uninitialized in msadpcm_encode_block().

4. src/ogg.c: Fix compiler warning

   Comparison of distinct pointer types lacks a cast in ogg_read_first_page().