### PR TITLE
CMake: Fix manpages installation on some platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -726,19 +726,20 @@ else ()
 endif ()
 
 if (INSTALL_MANPAGES)
+
 	set (man_MANS
 		man/sndfile-info.1
 		man/sndfile-play.1
 		man/sndfile-convert.1
 		man/sndfile-cmp.1
 		man/sndfile-metadata-get.1
-		man/sndfile-metadata-set.1
 		man/sndfile-concat.1
 		man/sndfile-interleave.1
-		man/sndfile-deinterleave.1
 		man/sndfile-salvage.1
 		)
 	install (FILES ${man_MANS} DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+	install (FILES man/sndfile-metadata-get.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 RENAME sndfile-metadata-set.1)
+	install (FILES man/sndfile-interleave.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 RENAME sndfile-deinterleave.1)
 endif ()
 
 if (ENABLE_BOW_DOCS)


### PR DESCRIPTION

Two manpages are installed by Autotools as symlinks, on some platforms
they are not visible and installation fails with error.

Install these files with renaming to avoid errors.

Related to edc513a, #m-ab-s/media-autobuild_suite#1801