### PR TITLE
Improve UWP support

### DIFF
--- a/src/file_io.c
+++ b/src/file_io.c
@@ -777,6 +777,21 @@ psf_open_handle (PSF_FILE * pfile)
 				return NULL ;
 		} ;
 
+#if defined (WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+	if (!pfile->use_wchar)
+		return NULL ;
+
+	CREATEFILE2_EXTENDED_PARAMETERS cfParams = { 0 } ;
+	cfParams.dwSize = sizeof (CREATEFILE2_EXTENDED_PARAMETERS) ;
+	cfParams.dwFileAttributes = FILE_ATTRIBUTE_NORMAL ;
+
+	handle = CreateFile2 (pfile->path.wc, dwDesiredAccess, dwShareMode, dwCreationDistribution, &cfParams) ;
+
+	if (handle == INVALID_HANDLE_VALUE)
+		return NULL ;
+
+	return handle ;
+#else
 	if (pfile->use_wchar)
 		handle = CreateFileW (
 					pfile->path.wc,				/* pointer to name of the file */
@@ -802,6 +817,7 @@ psf_open_handle (PSF_FILE * pfile)
 		return NULL ;
 
 	return handle ;
+#endif
 } /* psf_open_handle */
 
 /* USE_WINDOWS_API */ static void


### PR DESCRIPTION
`CreateFile` is not available on  [UWP](https://docs.microsoft.com/en-us/windows/uwp/get-started/universal-application-platform-guide) platform, use `CreateFile2` instead.

Patch from Vcpkg's libsndfile port.