### PR TITLE
[Win32] Fix for MSVC

### DIFF
--- a/include/sndfile.h.in
+++ b/include/sndfile.h.in
@@ -345,7 +345,7 @@ typedef	struct SNDFILE_tag	SNDFILE ;
 ** and the Microsoft compiler.
 */
 
-#if (defined (_MSCVER) || defined (_MSC_VER) && (_MSC_VER < 1310))
+#if defined (_MSC_VER) 
 typedef __int64		sf_count_t ;
 #define SF_COUNT_MAX		0x7fffffffffffffffi64
 #else


### PR DESCRIPTION
* A `_MSCVER` has never been a built-in for the MSVC compiler.
* Simply use the same `SF_COUNT_MAX` for all MSVC compilers.