### PR TITLE
[Win32] support both '\\' and '/' in path-names

### DIFF
--- a/regtest/database.c
+++ b/regtest/database.c
@@ -71,6 +71,14 @@ static int check_file_by_ekey (REGTEST_DB * db, int ekey) ;
 static int count_callback (REGTEST_DB * db, int argc, char **argv, char **colname) ;
 static int ekey_max_callback (REGTEST_DB * db, int argc, char **argv, char **colname) ;
 static int callback (void *unused, int argc, char **argv, char **colname) ;
+static const char *db_basename (const char *fname);
+
+/* Windows accepts both '\\' and '/' in paths */
+#ifdef _WIN32
+  #define IS_SLASH(c)  ((c) == '\\' || (c) == '/')
+#else
+  #define IS_SLASH(c)  ((c) == '/')
+#endif
 
 REG_DB *
 db_open (const char * db_name)
@@ -140,14 +148,12 @@ db_close (REG_DB * db_handle)
 int
 db_file_exists (REG_DB * db_handle, const char * filename)
 {	REGTEST_DB * db ;
-	const char * cptr ;
 	char * errmsg ;
 	int err ;
 
 	db = (REGTEST_DB *) db_handle ;
 
-	if ((cptr = strrchr (filename, '/')) != NULL)
-		filename = cptr + 1 ;
+	filename = db_basename (filename);
 
 	snprintf (db->cmdbuf, sizeof (db->cmdbuf), "select fname from sndfile where fname='%s'", filename) ;
 
@@ -417,10 +423,10 @@ check_file_by_ekey (REGTEST_DB * db, int ekey)
 
 static void
 get_filename_pathname (REGTEST_DB * db, const char *filepath)
-{	const char * cptr ;
+{	const char * basename ;
 	int slen ;
 
-	if (filepath [0] != '/')
+	if (!IS_SLASH(filepath [0]))
 	{	memset (db->pathname, 0, sizeof (db->pathname)) ;
 		if (getcwd (db->pathname, sizeof (db->pathname)) == NULL)
 		{	perror ("\ngetcwd failed") ;
@@ -428,18 +434,19 @@ get_filename_pathname (REGTEST_DB * db, const char *filepath)
 			} ;
 
 		slen = strlen (db->pathname) ;
-		db->pathname [slen ++] = '/' ;
+		db->pathname [slen ++] = '/' ;  /* a '/' is fine for Windows too */
 		snprintf (db->pathname + slen, sizeof (db->pathname) - slen, "%s", filepath) ;
 		}
 	else
 		snprintf (db->pathname, sizeof (db->pathname), "%s", filepath) ;
 
-	if ((cptr = strrchr (db->pathname, '/')) == NULL)
+	basename = db_basename (db->pathname) ;
+	if (basename == db->pathname)
 	{	printf ("\nError : bad pathname %s\n", filepath) ;
 		exit (1) ;
 		} ;
 
-	snprintf (db->filename, sizeof (db->filename), "%s", cptr + 1) ;
+	snprintf (db->filename, sizeof (db->filename), "%s", basename) ;
 } /* get filename_pathname */
 
 static void
@@ -485,6 +492,33 @@ callback (void *unused, int argc, char **argv, char **colname)
 
 	return 0 ;
 } /* callback */
+
+/*
+ * Win32:     Strip drive-letter and directory from a filename.
+ * non-Win32: Strip directory from a filename.
+ */
+static const char *db_basename (const char *fname)
+{
+	const char *base = fname ;
+
+#if !defined(_WIN32)
+	const char *slash = strrchr (base, '/') ;
+
+	if (slash)
+		base = slash + 1 ;
+#else
+	if (fname[0] && fname[1] == ':')  {
+		fname += 2;
+		base = fname;
+	}
+	while (*fname) {
+		if (IS_SLASH(*fname))
+			base = fname + 1;
+		fname++;
+	}
+#endif
+	return base ;
+}
 
 #else
 


### PR DESCRIPTION
To get a working `sndfile-regtest.exe` for Windows, the assumption of 
only `'/'` on paths caused strange and non-intuitive errors like: `Not a valid SNDFILE* pointer.`

And BTW, since the Windows-Kit has `winsqlite3.h`, this could be used instead of `sqlite3.h`. Later.