### PR TITLE
Fix MacOS 10.13 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ if (POLICY CMP0091)
 	cmake_policy (SET CMP0091 NEW)
 endif ()
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
+
 project(sndfile VERSION 1.0.30)
 
 #


### PR DESCRIPTION
When building the library on MacOS 10.15, the application using it crash on the first readf() call:

```
System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Reason:    DYLD, [0x4] Symbol missing

Dyld Error Message:
  Symbol not found: ____chkstk_darwin
  Referenced from: /Path/To/MyApplication.app/Contents/MacOS/../Frameworks/libsndfile.1.dylib (which was built for Mac OS X 10.15)
  Expected in: /usr/lib/libSystem.B.dylib

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   dyld                          	0x0000000109df524a __abort_with_payload + 10
1   dyld                          	0x0000000109df4bbc abort_with_payload_wrapper_internal + 89
2   dyld                          	0x0000000109df4be9 abort_with_payload + 9
3   dyld                          	0x0000000109dc8482 dyld::halt(char const*) + 354
4   dyld                          	0x0000000109dc85a9 dyld::fastBindLazySymbol(ImageLoader**, unsigned long) + 170
5   libdyld.dylib                 	0x00007fff6d0e2292 dyld_stub_binder + 282
6   ???                           	0x0000000102a021d0 0 + 4339016144
7   libsndfile.1.dylib            	0x00000001029945fb sf_readf_short + 299
```

Specifying MacOS compatibility seems to fix the issue.